### PR TITLE
Update README and bump patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ use on acceleration hardware. It is both efficient for single-core training, and
 scalable to massively parallel simulation, without the need for pesky
 datacenters.
 
-<img src="./docs/img/ant.gif" width="150" height="107"/><img src="./docs/img/fetch.gif" width="150" height="107"/><img src="./docs/img/grasp.gif" width="150" height="107"/><img src="./docs/img/halfcheetah.gif" width="150" height="107"/><img src="./docs/img/humanoid.gif" width="150" height="107"/>
+<img src="https://github.com/google/brax/raw/main/docs/img/ant.gif" width="150" height="107"/><img src="https://github.com/google/brax/raw/main/docs/img/fetch.gif" width="150" height="107"/><img src="https://github.com/google/brax/raw/main/docs/img/grasp.gif" width="150" height="107"/><img src="https://github.com/google/brax/raw/main/docs/img/halfcheetah.gif" width="150" height="107"/><img src="https://github.com/google/brax/raw/main/docs/img/humanoid.gif" width="150" height="107"/>
 
 *Some policies trained via Brax. Brax simulates these environments at millions of physics steps per second on TPU.*
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup
 
 setup(
     name="brax",
-    version="0.0.1",
+    version="0.0.2",
     description=("A differentiable physics engine written in JAX."),
     author="Brax Authors",
     author_email="no-reply@google.com",


### PR DESCRIPTION
Regarding #5.

Made `README.md` links absolute so the gifs show up on [PyPI](https://pypi.org/project/brax/). Bumped the patch version to 0.0.2 (with great, great apologies...) because I uploaded 0.0.1 to PyPI and the gif links were relative (and thus broken). PyPI will not allow the same version of a package name to be uploaded.