### PR TITLE
Remove tensorflow dependency for the env

### DIFF
--- a/brax/io/__init__.py
+++ b/brax/io/__init__.py
@@ -12,3 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+GFile = None
+try:
+  from tensorflow.io.gfile import GFile
+except:
+  pass
+
+class File:
+  def __init__ (self, fileName, mode='r'):
+    if GFile is not None:
+      self.f = GFile(fileName, mode)
+    else:
+      self.f = open(fileName)
+  def __enter__ (self):
+    return self.f
+  def __exit__ (self, exc_type, exc_value, traceback):
+    self.f.close()

--- a/brax/io/__init__.py
+++ b/brax/io/__init__.py
@@ -23,7 +23,7 @@ class File:
     if GFile is not None:
       self.f = GFile(fileName, mode)
     else:
-      self.f = open(fileName)
+      self.f = open(fileName, mode)
   def __enter__ (self):
     return self.f
   def __exit__ (self, exc_type, exc_value, traceback):

--- a/brax/io/file.py
+++ b/brax/io/file.py
@@ -11,3 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+class File:
+
+  def __init__ (self, fileName, mode='r'):
+    self.f = open(fileName, mode)
+
+  def __enter__ (self):
+    return self.f
+
+  def __exit__ (self, exc_type, exc_value, traceback):
+    self.f.close()

--- a/brax/io/html.py
+++ b/brax/io/html.py
@@ -19,7 +19,7 @@ from typing import List
 
 import brax
 from brax.io.json import JaxEncoder
-from tensorflow.io import gfile
+from brax.io import File
 
 
 from google.protobuf import json_format
@@ -27,7 +27,7 @@ from google.protobuf import json_format
 
 def save_html(path: str, sys: brax.System, qps: List[brax.QP]):
   """Saves trajectory as a HTML file."""
-  with gfile.GFile(path, 'wb') as fout:
+  with File(path, 'wb') as fout:
     fout.write(render(sys, qps))
 
 

--- a/brax/io/html.py
+++ b/brax/io/html.py
@@ -27,7 +27,7 @@ from google.protobuf import json_format
 
 def save_html(path: str, sys: brax.System, qps: List[brax.QP]):
   """Saves trajectory as a HTML file."""
-  with File(path, 'wb') as fout:
+  with File(path, 'w') as fout:
     fout.write(render(sys, qps))
 
 

--- a/brax/io/html.py
+++ b/brax/io/html.py
@@ -19,7 +19,7 @@ from typing import List
 
 import brax
 from brax.io.json import JaxEncoder
-from brax.io import File
+from brax.io.file import File
 
 
 from google.protobuf import json_format

--- a/brax/io/json.py
+++ b/brax/io/json.py
@@ -19,7 +19,7 @@ from typing import List
 
 import jax.numpy as np
 import brax
-from brax.io import File
+from brax.io.file import File
 
 from google.protobuf import json_format
 

--- a/brax/io/json.py
+++ b/brax/io/json.py
@@ -19,7 +19,7 @@ from typing import List
 
 import jax.numpy as np
 import brax
-import tensorflow as tf
+from brax.io import File
 
 from google.protobuf import json_format
 
@@ -33,7 +33,7 @@ class JaxEncoder(json.JSONEncoder):
 
 
 def save(path: str, sys: brax.System, qps: List[brax.QP]):
-  with tf.io.gfile.GFile(path, 'w') as fout:
+  with File(path, 'w') as fout:
     d = {'config': json_format.MessageToDict(sys.config, True),
          'pos': [qp.pos for qp in qps],
          'rot': [qp.rot for qp in qps],}


### PR DESCRIPTION
## Description

This PR makes the use of `tensorflow.io.gfile` optional: if `tensorflow` is available, it's going to use `gfile`, otherwise it would use the default python file system to save files.

I tested `html.save_html` with both `gfile` and regular `open` and they both work.

```
import jax
import brax
import sys
from brax import envs
from brax.io import html
env_name = "ant"  # @param ['ant', 'humanoid', 'fetch', 'grasp', 'halfcheetah', 'ur5e', 'reacher']
env = envs.create_gym_env(env_name=env_name)
state = env.reset()

print(html.render(env._environment.sys, [env._state.qp]))
html.save_html("test.html", env._environment.sys, [env._state.qp])
```