### PR TITLE
Add wrapper for easy conversion to/from PyTorch Tensors

### DIFF
--- a/brax/envs/__init__.py
+++ b/brax/envs/__init__.py
@@ -31,14 +31,14 @@ from brax.envs import ur5e
 from brax.envs import wrappers
 
 _envs = {
-  'fetch': fetch.Fetch,
-  'ant': ant.Ant,
-  'grasp': grasp.Grasp,
-  'halfcheetah': halfcheetah.Halfcheetah,
-  'humanoid': humanoid.Humanoid,
-  'ur5e': ur5e.Ur5e,
-  'reacher': reacher.Reacher,
-  'reacherangle': reacherangle.ReacherAngle,
+    'fetch': fetch.Fetch,
+    'ant': ant.Ant,
+    'grasp': grasp.Grasp,
+    'halfcheetah': halfcheetah.Halfcheetah,
+    'humanoid': humanoid.Humanoid,
+    'ur5e': ur5e.Ur5e,
+    'reacher': reacher.Reacher,
+    'reacherangle': reacherangle.ReacherAngle,
 }
 State = env.State
 Env = env.Env

--- a/brax/envs/__init__.py
+++ b/brax/envs/__init__.py
@@ -31,32 +31,34 @@ from brax.envs import ur5e
 from brax.envs import wrappers
 
 _envs = {
-    'fetch': fetch.Fetch,
-    'ant': ant.Ant,
-    'grasp': grasp.Grasp,
-    'halfcheetah': halfcheetah.Halfcheetah,
-    'humanoid': humanoid.Humanoid,
-    'ur5e': ur5e.Ur5e,
-    'reacher': reacher.Reacher,
-    'reacherangle': reacherangle.ReacherAngle,
+    "fetch": fetch.Fetch,
+    "ant": ant.Ant,
+    "grasp": grasp.Grasp,
+    "halfcheetah": halfcheetah.Halfcheetah,
+    "humanoid": humanoid.Humanoid,
+    "ur5e": ur5e.Ur5e,
+    "reacher": reacher.Reacher,
+    "reacherangle": reacherangle.ReacherAngle,
 }
 State = env.State
 Env = env.Env
 
 
 def create(env_name: str, **kwargs) -> Env:
-  """Creates an Env with a specified brax system."""
-  return _envs[env_name](**kwargs)
+    """Creates an Env with a specified brax system."""
+    return _envs[env_name](**kwargs)
 
 
 def create_fn(env_name: str, **kwargs) -> Callable[..., Env]:
-  """Returns a function that when called, creates an Env."""
-  return functools.partial(create, env_name, **kwargs)
+    """Returns a function that when called, creates an Env."""
+    return functools.partial(create, env_name, **kwargs)
 
 
-def create_gym_env(env_name: str, seed: int = 0, **kwargs) -> gym.Env:
-  environment = create(env_name=env_name, **kwargs)
-  if environment.batch_size:
-    return wrappers.VectorGymWrapper(environment, seed=seed)
-  else:
-    return wrappers.GymWrapper(environment, seed=seed)
+def create_gym_env(
+    env_name: str, seed: int = 0, backend: str = "cpu", **kwargs
+) -> gym.Env:
+    environment = create(env_name=env_name, **kwargs)
+    if environment.batch_size:
+        return wrappers.VectorGymWrapper(environment, seed=seed, backend=backend)
+    else:
+        return wrappers.GymWrapper(environment, seed=seed, backend=backend)

--- a/brax/envs/__init__.py
+++ b/brax/envs/__init__.py
@@ -31,80 +31,80 @@ from brax.envs import ur5e
 from brax.envs import wrappers
 
 _envs = {
-    "fetch": fetch.Fetch,
-    "ant": ant.Ant,
-    "grasp": grasp.Grasp,
-    "halfcheetah": halfcheetah.Halfcheetah,
-    "humanoid": humanoid.Humanoid,
-    "ur5e": ur5e.Ur5e,
-    "reacher": reacher.Reacher,
-    "reacherangle": reacherangle.ReacherAngle,
+  'fetch': fetch.Fetch,
+  'ant': ant.Ant,
+  'grasp': grasp.Grasp,
+  'halfcheetah': halfcheetah.Halfcheetah,
+  'humanoid': humanoid.Humanoid,
+  'ur5e': ur5e.Ur5e,
+  'reacher': reacher.Reacher,
+  'reacherangle': reacherangle.ReacherAngle,
 }
 State = env.State
 Env = env.Env
 
 
 def create(env_name: str, **kwargs) -> Env:
-    """Creates an Env with a specified brax system."""
-    return _envs[env_name](**kwargs)  # type: ignore
+  """Creates an Env with a specified brax system."""
+  return _envs[env_name](**kwargs)  # type: ignore
 
 
 def create_fn(env_name: str, **kwargs) -> Callable[..., Env]:
-    """Returns a function that when called, creates an Env."""
-    return functools.partial(create, env_name, **kwargs)
+  """Returns a function that when called, creates an Env."""
+  return functools.partial(create, env_name, **kwargs)
 
 
 @overload
 def create_gym_env(
-    env_name: str,
-    batch_size: None = None,
-    seed: int = 0,
-    backend: Optional[str] = None,
-    **kwargs
+  env_name: str,
+  batch_size: None = None,
+  seed: int = 0,
+  backend: Optional[str] = None,
+  **kwargs
 ) -> gym.Env:
-    ...
+  ...
 
 
 @overload
 def create_gym_env(
-    env_name: str,
-    batch_size: int,
-    seed: int = 0,
-    backend: Optional[str] = None,
-    **kwargs
+  env_name: str,
+  batch_size: int,
+  seed: int = 0,
+  backend: Optional[str] = None,
+  **kwargs
 ) -> gym.vector.VectorEnv:
-    ...
+  ...
 
 
 def create_gym_env(
-    env_name: str,
-    batch_size: Optional[int] = None,
-    seed: int = 0,
-    backend: Optional[str] = None,
-    **kwargs
+  env_name: str,
+  batch_size: Optional[int] = None,
+  seed: int = 0,
+  backend: Optional[str] = None,
+  **kwargs
 ) -> Union[gym.Env, gym.vector.VectorEnv]:
-    """Creates a `gym.Env` or `gym.vector.VectorEnv` from a Brax environment.
+  """Creates a `gym.Env` or `gym.vector.VectorEnv` from a Brax environment.
 
-    Parameters
-    ----------
-    env_name : str
-        Name of the environment to create.
-    batch_size : Optional[int], optional
-        Number of parallel environments. Defaults to `None`, in which case a single env
-        is returned. When `batch_size` > 1, a subclass of `gym.vector.VectorEnv` is
-        returned instead.
-    seed : int, optional
-        Random seed, by default 0.
-    backend : str, optional
-        Backend used for jit compilation of the `reset` and `step` methods. Defaults to
-        `None`, in which case the backend is chosen automatically.
+  Parameters
+  ----------
+  env_name : str
+    Name of the environment to create.
+  batch_size : Optional[int], optional
+    Number of parallel environments. Defaults to `None`, in which case a single env
+    is returned. When `batch_size` > 1, a subclass of `gym.vector.VectorEnv` is
+    returned instead.
+  seed : int, optional
+    Random seed, by default 0.
+  backend : str, optional
+    Backend used for jit compilation of the `reset` and `step` methods. Defaults to
+    `None`, in which case the backend is chosen automatically.
 
-    Returns
-    -------
-    Union[gym.Env, gym.vector.VectorEnv]
-        A `gym.Env` or a gym.vector.VectorEnv`, depending on the value of `batch_size`.
-    """
-    environment = create(env_name=env_name, batch_size=batch_size, **kwargs)
-    if batch_size:
-        return wrappers.VectorGymWrapper(environment, seed=seed, backend=backend)
-    return wrappers.GymWrapper(environment, seed=seed, backend=backend)
+  Returns
+  -------
+  Union[gym.Env, gym.vector.VectorEnv]
+      A `gym.Env` or a gym.vector.VectorEnv`, depending on the value of `batch_size`.
+  """
+  environment = create(env_name=env_name, batch_size=batch_size, **kwargs)
+  if batch_size:
+    return wrappers.VectorGymWrapper(environment, seed=seed, backend=backend)
+  return wrappers.GymWrapper(environment, seed=seed, backend=backend)

--- a/brax/envs/__init__.py
+++ b/brax/envs/__init__.py
@@ -62,6 +62,28 @@ def create_gym_env(
     backend: str = "cpu",
     **kwargs
 ) -> wrappers.GymWrapper:
+    """Creates a `gym.Env` or `gym.vector.VectorEnv` instance from a Brax environment.
+
+    Parameters
+    ----------
+    env_name : str
+        Name of the environment to create.
+    batch_size : Optional[int], optional
+        Number of parallel environments. Defaults to `None`, in which case a single env
+        is returned. When `batch_size` > 1, a subclass of `gym.vector.VectorEnv` is
+        returned instead.
+    seed : int, optional
+        Random seed, by default 0.
+    backend : str, optional
+        Backend used for jit compilation of the `reset` and `step` methods. Defaults to
+        "cpu".
+
+    Returns
+    -------
+    Union[wrappers.GymWrapper, wrappers.VectorGymWrapper]
+        A `wrappers.GymWrapper` or a `wrappers.VectorGymWrapper`, depending on the value
+        of `batch_size`.
+    """
     ...
 
 
@@ -79,28 +101,6 @@ def create_gym_env(
     backend: str = "cpu",
     **kwargs
 ) -> Union[wrappers.GymWrapper, wrappers.VectorGymWrapper]:
-    """Creates a gym wrapper around a Brax env.
-
-    Parameters
-    ----------
-    env_name : str
-        Name of the environment to create.
-    batch_size : Optional[int], optional
-        Number of parallel environments. Defaults to `None`, in which case a single env
-        is returned. When `batch_size` > 1, a subclass of `gym.vector.VectorEnv` is
-        returned.
-    seed : int, optional
-        Random seed, by default 0.
-    backend : str, optional
-        Backend used for jit compilation of the `reset` and `step` methods. Defaults to
-        "cpu".
-
-    Returns
-    -------
-    Union[wrappers.GymWrapper, wrappers.VectorGymWrapper]
-        A `wrappers.GymWrapper` or a `wrappers.VectorGymWrapper`, depending on the value
-        of `batch_size`.
-    """
     environment = create(env_name=env_name, batch_size=batch_size, **kwargs)
     if batch_size:
         return wrappers.VectorGymWrapper(environment, seed=seed, backend=backend)

--- a/brax/envs/__init__.py
+++ b/brax/envs/__init__.py
@@ -15,7 +15,7 @@
 """Some example environments to help get started quickly with brax."""
 
 import functools
-from typing import Callable, Optional, Union, overload
+from typing import Callable, Optional, Union, overload, Dict, Type
 
 import gym
 import brax
@@ -30,7 +30,7 @@ from brax.envs import reacherangle
 from brax.envs import ur5e
 from brax.envs import wrappers
 
-_envs = {
+_envs: Dict[str, Type[env.Env]] = {
     "fetch": fetch.Fetch,
     "ant": ant.Ant,
     "grasp": grasp.Grasp,
@@ -46,7 +46,7 @@ Env = env.Env
 
 def create(env_name: str, **kwargs) -> Env:
     """Creates an Env with a specified brax system."""
-    return _envs[env_name](**kwargs)  # type: ignore
+    return _envs[env_name](**kwargs)
 
 
 def create_fn(env_name: str, **kwargs) -> Callable[..., Env]:
@@ -79,6 +79,28 @@ def create_gym_env(
     backend: str = "cpu",
     **kwargs
 ) -> Union[wrappers.GymWrapper, wrappers.VectorGymWrapper]:
+    """Creates a gym wrapper around a Brax env.
+
+    Parameters
+    ----------
+    env_name : str
+        Name of the environment to create.
+    batch_size : Optional[int], optional
+        Number of parallel environments. Defaults to `None`, in which case a single env
+        is returned. When `batch_size` > 1, a subclass of `gym.vector.VectorEnv` is
+        returned.
+    seed : int, optional
+        Random seed, by default 0.
+    backend : str, optional
+        Backend used for jit compilation of the `reset` and `step` methods. Defaults to
+        "cpu".
+
+    Returns
+    -------
+    Union[wrappers.GymWrapper, wrappers.VectorGymWrapper]
+        A `wrappers.GymWrapper` or a `wrappers.VectorGymWrapper`, depending on the value
+        of `batch_size`.
+    """
     environment = create(env_name=env_name, batch_size=batch_size, **kwargs)
     if batch_size:
         return wrappers.VectorGymWrapper(environment, seed=seed, backend=backend)

--- a/brax/envs/__init__.py
+++ b/brax/envs/__init__.py
@@ -105,6 +105,8 @@ def create_gym_env(
       A `gym.Env` or a gym.vector.VectorEnv`, depending on the value of `batch_size`.
   """
   environment = create(env_name=env_name, batch_size=batch_size, **kwargs)
-  if batch_size:
+  if batch_size is not None:
+    if batch_size <= 0:
+      raise ValueError("`batch_size` should either be None or a positive integer.")
     return wrappers.VectorGymWrapper(environment, seed=seed, backend=backend)
   return wrappers.GymWrapper(environment, seed=seed, backend=backend)

--- a/brax/envs/to_torch.py
+++ b/brax/envs/to_torch.py
@@ -18,20 +18,20 @@ from jaxlib.xla_extension import DeviceArray
 from torch import Tensor
 from torch.utils import dlpack as torch_dlpack
 
-from brax.envs.wrappers import GymWrapper
+from brax.envs.wrappers import GymWrapper, VectorGymWrapper
 
 
 class JaxToTorchWrapper(gym.Wrapper):
     """Wrapper that converts Jax tensors to PyTorch tensors."""
 
-    def __init__(self, env: GymWrapper, device: torch.device = None):
-        """Creates a Wrapper around a `GymWrapper` or `VecGymWrapper` so it outputs
+    def __init__(self, env: Union[GymWrapper, VectorGymWrapper], device: torch.device = None):
+        """Creates a Wrapper around a `GymWrapper` or `VectorGymWrapper` so it outputs
         PyTorch tensors.
 
         Parameters
         ----------
-        env : Union[GymWrapper, VecGymWrapper]
-            A `GymWrapper` or `VecGymWrapper` to wrap.
+        env : Union[GymWrapper, VectorGymWrapper]
+            A `GymWrapper` or `VectorGymWrapper` to wrap.
         device : torch.device, optional
             device on which to move the Tensors. Defaults to `None`, in which case the
             tensors will be on the same devices as their Jax equivalents.
@@ -77,7 +77,7 @@ class JaxToTorchWrapper(gym.Wrapper):
 def torch_to_jax(v: Any) -> Any:
     """Converts values to JAX tensors."""
     # Don't do anything by default, and when a handler is registered for this type of
-    # value, it gets used to convert it to a torch tensor.
+    # value, it gets used to convert it to a Jax DeviceArray.
     # NOTE: The alternative would be to raise an error when an unsupported value is
     # encountered:
     # raise NotImplementedError(f"Don't know how to convert {v} to a Jax tensor")

--- a/brax/envs/to_torch.py
+++ b/brax/envs/to_torch.py
@@ -1,0 +1,133 @@
+""" Wrapper around a Brax GymWrapper, that converts its outputs to PyTorch tensors.
+
+This conversion happens direcly on-device, witout the need to move values to the CPU.
+"""
+
+import datetime
+import time
+from collections import abc
+from functools import partial, singledispatch
+from typing import Any, Dict, Mapping, Optional, TypeVar, Union
+
+import gym
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from jax._src import dlpack as jax_dlpack
+from jaxlib.xla_extension import DeviceArray
+from torch import Tensor
+from torch.utils import dlpack as torch_dlpack
+
+from brax.envs.wrappers import GymWrapper
+
+
+class JaxToTorchWrapper(gym.Wrapper):
+    """Wrapper that converts Jax tensors to PyTorch tensors."""
+
+    def __init__(self, env: GymWrapper, device: torch.device = None):
+        """Creates a Wrapper around a `GymWrapper` or `VecGymWrapper` so it outputs
+        PyTorch tensors.
+
+        Parameters
+        ----------
+        env : Union[GymWrapper, VecGymWrapper]
+            A `GymWrapper` or `VecGymWrapper` to wrap.
+        device : torch.device, optional
+            device on which to move the Tensors. Defaults to `None`, in which case the
+            tensors will be on the same devices as their Jax equivalents.
+        """
+        if not hasattr(env, "reward_range"):
+            # NOTE: Fix a bug with the current GymWrapper, where the `Env` doesn't have
+            # the `reward_range` attribute which is needed by the gym.Wrapper
+            # constructor.
+            env.reward_range = (-np.inf, np.inf)
+        super().__init__(env)
+        self.device: Optional[torch.device] = device
+
+    def observation(self, observation):
+        return jax_to_torch(observation, device=self.device)
+
+    def action(self, action):
+        return torch_to_jax(action)
+
+    def reward(self, reward):
+        return jax_to_torch(reward, device=self.device)
+
+    def done(self, done: DeviceArray) -> Tensor:
+        return jax_to_torch(done, device=self.device)
+
+    def info(self, info: Dict) -> Dict:
+        return jax_to_torch(info, device=self.device)
+
+    def reset(self):
+        obs = super().reset()
+        return self.observation(obs)
+
+    def step(self, action):
+        action = self.action(action)
+        obs, rewards, done, info = super().step(action)
+        obs = self.observation(obs)
+        rewards = self.reward(rewards)
+        done = self.done(done)
+        info = self.info(info)
+        return obs, rewards, done, info
+
+
+@singledispatch
+def torch_to_jax(v: Any) -> Any:
+    """Converts values to JAX tensors."""
+    # Don't do anything by default, and when a handler is registered for this type of
+    # value, it gets used to convert it to a torch tensor.
+    # NOTE: The alternative would be to raise an error when an unsupported value is
+    # encountered:
+    # raise NotImplementedError(f"Don't know how to convert {v} to a Jax tensor")
+    return v
+
+
+@torch_to_jax.register(Tensor)
+def _tensor_to_jax(v: Tensor) -> DeviceArray:
+    """Converts a PyTorch Tensor into a Jax DeviceArray."""
+    tensor = torch_dlpack.to_dlpack(v)
+    tensor = jax_dlpack.from_dlpack(tensor)
+    return tensor
+
+
+@torch_to_jax.register(abc.Mapping)
+def _torch_dict_to_jax(
+    v: Dict[str, Union[Tensor, Any]]
+) -> Dict[str, Union[DeviceArray, Any]]:
+    """Converts a dict of PyTorch tensors into a dict of Jax DeviceArrays."""
+    return type(v)(**{k: torch_to_jax(value) for k, value in v.items()})
+
+
+@singledispatch
+def jax_to_torch(v: Any, device: torch.device = None) -> Any:
+    """Convert JAX values to PyTorch Tensors.
+
+    By default, the returned tensors are on the same device as the Jax inputs, but if
+    `device` is passed, the tensors will be moved to that device.
+    """
+    # Don't do anything by default, and when a handler is registered for this type of
+    # value, it gets used to convert it to a torch tensor.
+    # NOTE: The alternative would be to raise an error when an unsupported value is
+    # encountered:
+    # raise NotImplementedError(f"Don't know how to convert {v} to a Torch tensor")
+    return v
+
+
+@jax_to_torch.register(DeviceArray)
+def _devicearray_to_tensor(v: DeviceArray, device: torch.device = None) -> Tensor:
+    """Converts a Jax DeviceArray into PyTorch Tensor."""
+    dpack = jax_dlpack.to_dlpack(v)
+    tensor = torch_dlpack.from_dlpack(dpack)
+    if device:
+        return tensor.to(device=device)
+    return tensor
+
+
+@jax_to_torch.register(abc.Mapping)
+def _jax_dict_to_torch(
+    v: Dict[str, Union[DeviceArray, Any]], device: torch.device = None
+) -> Dict[str, Union[Tensor, Any]]:
+    """Converts a dict of Jax DeviceArrays into a dict of PyTorch tensors."""
+    return type(v)(**{k: jax_to_torch(value, device=device) for k, value in v.items()})

--- a/brax/envs/to_torch.py
+++ b/brax/envs/to_torch.py
@@ -1,30 +1,23 @@
 """ Wrapper around a Brax GymWrapper, that converts its outputs to PyTorch tensors.
 
-This conversion happens direcly on-device, witout the need to move values to the CPU.
+This conversion happens directly on-device, witout the need to move values to the CPU.
 """
-
-import datetime
-import time
-from collections import abc
-from functools import partial, singledispatch
-from typing import Any, Dict, Mapping, Optional, TypeVar, Union
-
+from typing import Optional, Union
 import gym
-import matplotlib.pyplot as plt
-import numpy as np
-import torch
-from jax._src import dlpack as jax_dlpack
-from jaxlib.xla_extension import DeviceArray
-from torch import Tensor
-from torch.utils import dlpack as torch_dlpack
 
 from brax.envs.wrappers import GymWrapper, VectorGymWrapper
+
+# NOTE: The following line will raise a warning and raise ImportError if `torch` isn't
+# available.
+from brax.io.torch import torch_to_jax, jax_to_torch, Device
 
 
 class JaxToTorchWrapper(gym.Wrapper):
     """Wrapper that converts Jax tensors to PyTorch tensors."""
 
-    def __init__(self, env: Union[GymWrapper, VectorGymWrapper], device: torch.device = None):
+    def __init__(
+        self, env: Union[GymWrapper, VectorGymWrapper], device: Optional[Device] = None
+    ):
         """Creates a Wrapper around a `GymWrapper` or `VectorGymWrapper` so it outputs
         PyTorch tensors.
 
@@ -32,17 +25,12 @@ class JaxToTorchWrapper(gym.Wrapper):
         ----------
         env : Union[GymWrapper, VectorGymWrapper]
             A `GymWrapper` or `VectorGymWrapper` to wrap.
-        device : torch.device, optional
+        device : Union[torch.device, str], optional
             device on which to move the Tensors. Defaults to `None`, in which case the
             tensors will be on the same devices as their Jax equivalents.
         """
-        if not hasattr(env, "reward_range"):
-            # NOTE: Fix a bug with the current GymWrapper, where the `Env` doesn't have
-            # the `reward_range` attribute which is needed by the gym.Wrapper
-            # constructor.
-            env.reward_range = (-np.inf, np.inf)
         super().__init__(env)
-        self.device: Optional[torch.device] = device
+        self.device: Optional[Device] = device
 
     def observation(self, observation):
         return jax_to_torch(observation, device=self.device)
@@ -53,10 +41,10 @@ class JaxToTorchWrapper(gym.Wrapper):
     def reward(self, reward):
         return jax_to_torch(reward, device=self.device)
 
-    def done(self, done: DeviceArray) -> Tensor:
+    def done(self, done):
         return jax_to_torch(done, device=self.device)
 
-    def info(self, info: Dict) -> Dict:
+    def info(self, info):
         return jax_to_torch(info, device=self.device)
 
     def reset(self):
@@ -65,69 +53,9 @@ class JaxToTorchWrapper(gym.Wrapper):
 
     def step(self, action):
         action = self.action(action)
-        obs, rewards, done, info = super().step(action)
+        obs, reward, done, info = super().step(action)
         obs = self.observation(obs)
-        rewards = self.reward(rewards)
+        reward = self.reward(reward)
         done = self.done(done)
         info = self.info(info)
-        return obs, rewards, done, info
-
-
-@singledispatch
-def torch_to_jax(v: Any) -> Any:
-    """Converts values to JAX tensors."""
-    # Don't do anything by default, and when a handler is registered for this type of
-    # value, it gets used to convert it to a Jax DeviceArray.
-    # NOTE: The alternative would be to raise an error when an unsupported value is
-    # encountered:
-    # raise NotImplementedError(f"Don't know how to convert {v} to a Jax tensor")
-    return v
-
-
-@torch_to_jax.register(Tensor)
-def _tensor_to_jax(v: Tensor) -> DeviceArray:
-    """Converts a PyTorch Tensor into a Jax DeviceArray."""
-    tensor = torch_dlpack.to_dlpack(v)
-    tensor = jax_dlpack.from_dlpack(tensor)
-    return tensor
-
-
-@torch_to_jax.register(abc.Mapping)
-def _torch_dict_to_jax(
-    v: Dict[str, Union[Tensor, Any]]
-) -> Dict[str, Union[DeviceArray, Any]]:
-    """Converts a dict of PyTorch tensors into a dict of Jax DeviceArrays."""
-    return type(v)(**{k: torch_to_jax(value) for k, value in v.items()})
-
-
-@singledispatch
-def jax_to_torch(v: Any, device: torch.device = None) -> Any:
-    """Convert JAX values to PyTorch Tensors.
-
-    By default, the returned tensors are on the same device as the Jax inputs, but if
-    `device` is passed, the tensors will be moved to that device.
-    """
-    # Don't do anything by default, and when a handler is registered for this type of
-    # value, it gets used to convert it to a torch tensor.
-    # NOTE: The alternative would be to raise an error when an unsupported value is
-    # encountered:
-    # raise NotImplementedError(f"Don't know how to convert {v} to a Torch tensor")
-    return v
-
-
-@jax_to_torch.register(DeviceArray)
-def _devicearray_to_tensor(v: DeviceArray, device: torch.device = None) -> Tensor:
-    """Converts a Jax DeviceArray into PyTorch Tensor."""
-    dpack = jax_dlpack.to_dlpack(v)
-    tensor = torch_dlpack.from_dlpack(dpack)
-    if device:
-        return tensor.to(device=device)
-    return tensor
-
-
-@jax_to_torch.register(abc.Mapping)
-def _jax_dict_to_torch(
-    v: Dict[str, Union[DeviceArray, Any]], device: torch.device = None
-) -> Dict[str, Union[Tensor, Any]]:
-    """Converts a dict of Jax DeviceArrays into a dict of PyTorch tensors."""
-    return type(v)(**{k: jax_to_torch(value, device=device) for k, value in v.items()})
+        return obs, reward, done, info

--- a/brax/envs/wrappers.py
+++ b/brax/envs/wrappers.py
@@ -20,12 +20,17 @@ from gym.vector import utils
 import jax
 import numpy as np
 from brax.envs import env
+from typing import ClassVar
 
 
 class GymWrapper(gym.Env):
   """A wrapper that converts Brax Env to one that follows Gym API."""
 
-  def __init__(self, environment: env.Env, seed: int = 0):
+  # Flag that prevents `gym.register` from misinterpreting the `_step` and `_reset` as
+  # signs of a deprecated gym Env API.
+  _gym_disable_underscore_compat: ClassVar[bool] = True
+
+  def __init__(self, environment: env.Env, seed: int = 0, backend: str = "cpu"):
     self._environment = environment
     self.seed(seed)
 
@@ -37,17 +42,18 @@ class GymWrapper(gym.Env):
     self.action_space = spaces.Box(-action_high, action_high, dtype=np.float32)
 
     self._state = None
+    self.backend = backend
 
     def reset(key):
       key1, key2 = jax.random.split(key)
       state = self._environment.reset(key2)
       return state, state.obs, key1
-    self._reset = jax.jit(reset)
+    self._reset = jax.jit(reset, backend=self.backend)
 
     def step(state, action):
       state = self._environment.step(state, action)
       return state, state.obs, state.reward, state.done
-    self._step = jax.jit(step, backend='cpu')
+    self._step = jax.jit(step, backend=self.backend)
 
   def reset(self):
     self._state, obs, self._key = self._reset(self._key)
@@ -64,7 +70,7 @@ class GymWrapper(gym.Env):
 class VectorGymWrapper(gym.vector.VectorEnv):
   """A wrapper that converts batched Brax Env to one that follows Gym VectorEnv API."""
 
-  def __init__(self, environment: env.Env, seed: int = 0):
+  def __init__(self, environment: env.Env, seed: int = 0, backend: str = "cpu"):
     self._environment = environment
     if not self._environment.batch_size:
       raise ValueError('underlying environment must be batched')
@@ -72,6 +78,7 @@ class VectorGymWrapper(gym.vector.VectorEnv):
     self.num_envs = self._environment.batch_size
     self._key_size = self.num_envs + 1
     self.seed(seed)
+    self.backend = backend
 
     obs_high = np.inf * np.ones(self._environment.observation_size)
     self.single_observation_space = spaces.Box(
@@ -90,12 +97,12 @@ class VectorGymWrapper(gym.vector.VectorEnv):
       keys = jax.random.split(key, self._key_size)
       state = self._environment.reset(keys[1:])
       return state, state.obs, keys[0]
-    self._reset = jax.jit(reset)
+    self._reset = jax.jit(reset, backend=self.backend)
 
     def step(state, action):
       state = self._environment.step(state, action)
       return state, state.obs, state.reward, state.done
-    self._step = jax.jit(step, backend='cpu')
+    self._step = jax.jit(step, backend=self.backend)
 
   def reset(self):
     self._state, obs, self._key = self._reset(self._key)

--- a/brax/envs/wrappers.py
+++ b/brax/envs/wrappers.py
@@ -70,6 +70,10 @@ class GymWrapper(gym.Env):
 class VectorGymWrapper(gym.vector.VectorEnv):
   """A wrapper that converts batched Brax Env to one that follows Gym VectorEnv API."""
 
+  # Flag that prevents `gym.register` from misinterpreting the `_step` and `_reset` as
+  # signs of a deprecated gym Env API.
+  _gym_disable_underscore_compat: ClassVar[bool] = True
+
   def __init__(self, environment: env.Env, seed: int = 0, backend: str = "cpu"):
     self._environment = environment
     if not self._environment.batch_size:

--- a/brax/envs/wrappers.py
+++ b/brax/envs/wrappers.py
@@ -20,7 +20,7 @@ from gym.vector import utils
 import jax
 import numpy as np
 from brax.envs import env
-from typing import ClassVar
+from typing import ClassVar, Optional
 
 
 class GymWrapper(gym.Env):
@@ -30,7 +30,7 @@ class GymWrapper(gym.Env):
   # signs of a deprecated gym Env API.
   _gym_disable_underscore_compat: ClassVar[bool] = True
 
-  def __init__(self, environment: env.Env, seed: int = 0, backend: str = "cpu"):
+  def __init__(self, environment: env.Env, seed: int = 0, backend: Optional[str] = None):
     self._environment = environment
     self.seed(seed)
 
@@ -74,7 +74,7 @@ class VectorGymWrapper(gym.vector.VectorEnv):
   # signs of a deprecated gym Env API.
   _gym_disable_underscore_compat: ClassVar[bool] = True
 
-  def __init__(self, environment: env.Env, seed: int = 0, backend: str = "cpu"):
+  def __init__(self, environment: env.Env, seed: int = 0, backend: Optional[str] = None):
     self._environment = environment
     if not self._environment.batch_size:
       raise ValueError('underlying environment must be batched')

--- a/brax/envs/wrappers.py
+++ b/brax/envs/wrappers.py
@@ -35,10 +35,10 @@ class GymWrapper(gym.Env):
     self.seed(seed)
 
     # action_space = None
-    obs_high = np.inf * np.ones(self._environment.observation_size)
+    obs_high = (np.inf * np.ones(self._environment.observation_size)).astype(np.float32)
     self.observation_space = spaces.Box(-obs_high, obs_high, dtype=np.float32)
 
-    action_high = np.ones(self._environment.action_size)
+    action_high = np.ones(self._environment.action_size, dtype=np.float32)
     self.action_space = spaces.Box(-action_high, action_high, dtype=np.float32)
 
     self._state = None
@@ -84,13 +84,13 @@ class VectorGymWrapper(gym.vector.VectorEnv):
     self.seed(seed)
     self.backend = backend
 
-    obs_high = np.inf * np.ones(self._environment.observation_size)
+    obs_high = (np.inf * np.ones(self._environment.observation_size)).astype(np.float32)
     self.single_observation_space = spaces.Box(
         -obs_high, obs_high, dtype=np.float32)
     self.observation_space = utils.batch_space(self.single_observation_space,
                                                self.num_envs)
 
-    action_high = np.ones(self._environment.action_size)
+    action_high = np.ones(self._environment.action_size, dtype=np.float32)
     self.single_action_space = spaces.Box(
         -action_high, action_high, dtype=np.float32)
     self.action_space = utils.batch_space(self.single_action_space,

--- a/brax/io/torch.py
+++ b/brax/io/torch.py
@@ -1,9 +1,9 @@
 """ Generic functions to convert Jax DeviceArrays into PyTorch Tensors and vice-versa.
 """
 import warnings
+from collections import abc
 from functools import singledispatch
 from typing import Any, Union, Dict
-from collections import abc
 
 from jax._src import dlpack as jax_dlpack
 from jaxlib.xla_extension import DeviceArray
@@ -12,8 +12,8 @@ try:
     import torch
 except ImportError:
     warnings.warn(
-        "to_torch requires PyTorch. Please run `pip install torch` for this function "
-        "to work."
+        "brax.io.torch requires PyTorch. Please run `pip install torch` to use "
+        "functions from this module."
     )
     raise
 

--- a/brax/io/torch.py
+++ b/brax/io/torch.py
@@ -1,0 +1,82 @@
+""" Generic functions to convert Jax DeviceArrays into PyTorch Tensors and vice-versa.
+"""
+import warnings
+from functools import singledispatch
+from typing import Any, Union, Dict
+from collections import abc
+
+from jax._src import dlpack as jax_dlpack
+from jaxlib.xla_extension import DeviceArray
+
+try:
+    import torch
+    from torch import Tensor
+    from torch.utils import dlpack as torch_dlpack
+except ImportError:
+    warnings.warn(
+        "to_torch requires PyTorch. Please run `pip install torch` for this function "
+        "to work."
+    )
+    raise
+
+Device = Union[str, torch.device]
+
+
+@singledispatch
+def torch_to_jax(value: Any) -> Any:
+    """Converts values to JAX tensors."""
+    # Don't do anything by default, and when a handler is registered for this type of
+    # value, it gets used to convert it to a Jax DeviceArray.
+    # NOTE: The alternative would be to raise an error when an unsupported value is
+    # encountered:
+    # raise NotImplementedError(f"Don't know how to convert {v} to a Jax tensor")
+    return value
+
+
+@torch_to_jax.register(Tensor)
+def _tensor_to_jax(value: Tensor) -> DeviceArray:
+    """Converts a PyTorch Tensor into a Jax DeviceArray."""
+    tensor = torch_dlpack.to_dlpack(value)
+    tensor = jax_dlpack.from_dlpack(tensor)
+    return tensor
+
+
+@torch_to_jax.register(abc.Mapping)
+def _torch_dict_to_jax(
+    value: Dict[str, Union[Tensor, Any]]
+) -> Dict[str, Union[DeviceArray, Any]]:
+    """Converts a dict of PyTorch tensors into a dict of Jax DeviceArrays."""
+    return type(value)(**{k: torch_to_jax(v) for k, v in value.items()})
+
+
+@singledispatch
+def jax_to_torch(value: Any, device: Device = None) -> Any:
+    """Convert JAX values to PyTorch Tensors.
+
+    By default, the returned tensors are on the same device as the Jax inputs, but if
+    `device` is passed, the tensors will be moved to that device.
+    """
+    # Don't do anything by default, and when a handler is registered for this type of
+    # value, it gets used to convert it to a torch tensor.
+    # NOTE: The alternative would be to raise an error when an unsupported value is
+    # encountered:
+    # raise NotImplementedError(f"Don't know how to convert {v} to a Torch tensor")
+    return value
+
+
+@jax_to_torch.register(DeviceArray)
+def _devicearray_to_tensor(value: DeviceArray, device: Device = None) -> Tensor:
+    """Converts a Jax DeviceArray into PyTorch Tensor."""
+    dpack = jax_dlpack.to_dlpack(value)
+    tensor = torch_dlpack.from_dlpack(dpack)
+    if device:
+        return tensor.to(device=device)
+    return tensor
+
+
+@jax_to_torch.register(abc.Mapping)
+def _jax_dict_to_torch(
+    value: Dict[str, Union[DeviceArray, Any]], device: Device = None
+) -> Dict[str, Union[Tensor, Any]]:
+    """Converts a dict of Jax DeviceArrays into a dict of PyTorch tensors."""
+    return type(value)(**{k: jax_to_torch(v, device=device) for k, v in value.items()})

--- a/brax/io/torch.py
+++ b/brax/io/torch.py
@@ -10,8 +10,6 @@ from jaxlib.xla_extension import DeviceArray
 
 try:
     import torch
-    from torch import Tensor
-    from torch.utils import dlpack as torch_dlpack
 except ImportError:
     warnings.warn(
         "to_torch requires PyTorch. Please run `pip install torch` for this function "
@@ -19,6 +17,8 @@ except ImportError:
     )
     raise
 
+from torch import Tensor
+from torch.utils import dlpack as torch_dlpack
 Device = Union[str, torch.device]
 
 

--- a/notebooks/gym_pytorch.ipynb
+++ b/notebooks/gym_pytorch.ipynb
@@ -1,0 +1,202 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/to_torch/notebooks/pytorch.ipynb)"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Using Brax with Gym + PyTorch"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "source": [
+    "# Imports:\n",
+    "import time\n",
+    "import torch\n",
+    "from functools import partial\n",
+    "import time\n",
+    "\n",
+    "import gym\n",
+    "import tqdm\n",
+    "import numpy as np\n",
+    "\n",
+    "from brax.envs.to_torch import JaxToTorchWrapper\n",
+    "from brax.envs import _envs, create_gym_env\n",
+    "\n",
+    "COLAB = \"google.colab\" in str(get_ipython())\n",
+    "\n",
+    "if COLAB:\n",
+    "    # Detect if running in Colab or not.\n",
+    "    from jax.tools import colab_tpu\n",
+    "    # configure jax to run on tpu:\n",
+    "    colab_tpu.setup_tpu()\n",
+    "\n",
+    "# Registering the Brax envs in Gym (so we can use `gym.make` as usual):\n",
+    "for env_name, env_class in _envs.items():\n",
+    "    env_id = f\"brax_{env_name}-v0\"\n",
+    "    entry_point = partial(create_gym_env, env_name=env_name)\n",
+    "    if env_id not in gym.envs.registry.env_specs:\n",
+    "        print(f\"Registring brax's '{env_name}' env under id '{env_id}'.\")\n",
+    "        gym.register(env_id, entry_point=entry_point)"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Benchmarking the performance of the Pytorch'ed Brax gym Env:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "source": [
+    "# Number of parallel environments\n",
+    "batch_size = 1024  #@param { type:\"slider\", min:0, max:4096, step: 1 }\n",
+    "\n",
+    "# Number of steps to take in the batched env.\n",
+    "n_steps = 1000\n",
+    "\n",
+    "# Simple utility function for benchmarking.\n",
+    "_times = [time.time()]\n",
+    "def tick(name: str = \"\"):\n",
+    "    _times.append(time.time())\n",
+    "    elapsed = times[-1] - times[-2]\n",
+    "    if name:\n",
+    "        print(f\"Time for {name}: {elapsed}\")\n",
+    "    return elapsed\n",
+    "\n",
+    "if torch.cuda.is_available():\n",
+    "    # BUG: (@lebrice): Getting a weird \"CUDA error: out of memory\" RuntimeError during\n",
+    "    # JIT, which can be \"fixed\" by first creating a dummy cuda tensor!\n",
+    "    v = torch.ones(1, device=\"cuda\")\n",
+    "\n",
+    "CUDA = torch.cuda.is_available()\n",
+    "\n",
+    "env = gym.make(\"brax_halfcheetah-v0\", batch_size=batch_size)\n",
+    "tick(\"Creating the env\")\n",
+    "\n",
+    "env = JaxToTorchWrapper(env)\n",
+    "tick(\"Wrapping the env\")\n",
+    "\n",
+    "obs = env.reset()  # this can be relatively slow (~10 secs)\n",
+    "tick(\"First reset\") \n",
+    "\n",
+    "obs, reward, done, info = env.step(env.action_space.sample())\n",
+    "tick(\"First step\")  # this can be relatively slow (~10 secs)\n",
+    "\n",
+    "obs, reward, done, info = env.step(env.action_space.sample())\n",
+    "tick(\"Second step\")  # this can be relatively slow (~10 secs)\n",
+    "\n",
+    "_times.clear()\n",
+    "_times.append(time.time())\n",
+    "\n",
+    "# Create a Progress bar. NOTE: This Pbar effectively shows the step rate as well!\n",
+    "pbar = tqdm.tqdm(range(n_steps), unit_scale=batch_size)\n",
+    "for i in pbar:\n",
+    "    # NOTE: Could use the `action_space` property like so even with CUDA, but we'd need\n",
+    "    # to move the numpy array from CPU to GPU/TPU, which would kind-of defeat the\n",
+    "    # purpose of this demo! Here we instead create a Tensor which is already on the GPU.\n",
+    "    if not CUDA:\n",
+    "        action = env.action_space.sample()\n",
+    "    else:\n",
+    "        action = torch.rand(env.action_space.shape, device=\"cuda\") * 2 - 1\n",
+    "    obs, rewards, done, info = env.step(action)\n",
+    "    tick()\n",
+    "\n",
+    "\n",
+    "elapsed_times = [times[i+1] - times[i] for i in range(len(times)-1)]\n",
+    "\n",
+    "time_for_n_steps_avg = np.mean(elapsed_times)\n",
+    "time_for_n_steps_std = np.std(elapsed_times)\n",
+    "\n",
+    "frequency =  1 / time_for_n_steps_avg\n",
+    "effective_frequency = (batch_size or 1) * frequency\n",
+    "\n",
+    "print(f\"Device used: {obs.device}\")\n",
+    "print(f\"Number of parallel environments: {batch_size}\")\n",
+    "print(f\"Average time per batched step:  {time_for_n_steps_avg} ± {time_for_n_steps_std} seconds\")\n",
+    "print(f\"Frequency (after first two steps): ~{frequency:.3f} batched steps / second.\")\n",
+    "print(f\"Effective Frequency (after first two steps): ~{effective_frequency:.3f} steps / second.\")"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Time for Creating the env: 0.0038437843322753906\n",
+      "Time for Wrapping the env: 0.0038437843322753906\n",
+      "Time for First reset: 0.0038437843322753906\n",
+      "Time for First step: 0.0038437843322753906\n",
+      "Time for Second step: 0.0038437843322753906\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "100%|██████████| 1024000/1024000 [00:03<00:00, 289150.23it/s]"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Device used: cuda:0\n",
+      "Number of parallel environments: 1024\n",
+      "Average time per batched step:  0.0039951517013366335 ± 0.00026153933497828803 seconds\n",
+      "Frequency: ~250.303 batched steps / second.\n",
+      "Effective Frequency: ~256310.668 steps / second.\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "metadata": {}
+  }
+ ],
+ "metadata": {
+  "orig_nbformat": 4,
+  "language_info": {
+   "name": "python",
+   "version": "3.8.10",
+   "mimetype": "text/x-python",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "pygments_lexer": "ipython3",
+   "nbconvert_exporter": "python",
+   "file_extension": ".py"
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.8.10 64-bit ('brax': conda)"
+  },
+  "interpreter": {
+   "hash": "1812c2cdf0067f1c111fe8b907e8717aab013f923026de8fa0a048a0a07a7c66"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/gym_pytorch.ipynb
+++ b/notebooks/gym_pytorch.ipynb
@@ -16,12 +16,14 @@
   },
   {
    "cell_type": "markdown",
-   "source": [],
+   "source": [
+    "Author: @lebrice (Fabrice Normandin)"
+   ],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "source": [
     "# Imports:\n",
     "import time\n",
@@ -36,10 +38,10 @@
     "from brax.envs.to_torch import JaxToTorchWrapper\n",
     "from brax.envs import _envs, create_gym_env\n",
     "\n",
+    "# Detect if running in Colab or not.\n",
     "COLAB = \"google.colab\" in str(get_ipython())\n",
     "\n",
     "if COLAB:\n",
-    "    # Detect if running in Colab or not.\n",
     "    from jax.tools import colab_tpu\n",
     "    # configure jax to run on tpu:\n",
     "    colab_tpu.setup_tpu()\n",
@@ -50,9 +52,39 @@
     "    entry_point = partial(create_gym_env, env_name=env_name)\n",
     "    if env_id not in gym.envs.registry.env_specs:\n",
     "        print(f\"Registring brax's '{env_name}' env under id '{env_id}'.\")\n",
-    "        gym.register(env_id, entry_point=entry_point)"
+    "        gym.register(env_id, entry_point=entry_point)\n",
+    "\n",
+    "# Simple utility function for benchmarking below.\n",
+    "def tick(name: str = \"\"):\n",
+    "    global _times\n",
+    "    _times.append(time.time())\n",
+    "    elapsed = _times[-1] - _times[-2]\n",
+    "    if name:\n",
+    "        print(f\"Time for {name}: {elapsed}\")\n",
+    "    return elapsed\n",
+    "\n",
+    "CUDA = torch.cuda.is_available()\n",
+    "if CUDA:\n",
+    "    # BUG: (@lebrice): Getting a weird \"CUDA error: out of memory\" RuntimeError during\n",
+    "    # JIT, which can be \"fixed\" by first creating a dummy cuda tensor!\n",
+    "    v = torch.ones(1, device=\"cuda\")\n"
    ],
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Registring brax's 'fetch' env under id 'brax_fetch-v0'.\n",
+      "Registring brax's 'ant' env under id 'brax_ant-v0'.\n",
+      "Registring brax's 'grasp' env under id 'brax_grasp-v0'.\n",
+      "Registring brax's 'halfcheetah' env under id 'brax_halfcheetah-v0'.\n",
+      "Registring brax's 'humanoid' env under id 'brax_humanoid-v0'.\n",
+      "Registring brax's 'ur5e' env under id 'brax_ur5e-v0'.\n",
+      "Registring brax's 'reacher' env under id 'brax_reacher-v0'.\n",
+      "Registring brax's 'reacherangle' env under id 'brax_reacherangle-v0'.\n"
+     ]
+    }
+   ],
    "metadata": {}
   },
   {
@@ -64,29 +96,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "source": [
+    "_times = [time.time()]\n",
+    "\n",
     "# Number of parallel environments\n",
     "batch_size = 1024  #@param { type:\"slider\", min:0, max:4096, step: 1 }\n",
     "\n",
     "# Number of steps to take in the batched env.\n",
     "n_steps = 1000\n",
     "\n",
-    "# Simple utility function for benchmarking.\n",
-    "_times = [time.time()]\n",
-    "def tick(name: str = \"\"):\n",
-    "    _times.append(time.time())\n",
-    "    elapsed = times[-1] - times[-2]\n",
-    "    if name:\n",
-    "        print(f\"Time for {name}: {elapsed}\")\n",
-    "    return elapsed\n",
     "\n",
-    "if torch.cuda.is_available():\n",
-    "    # BUG: (@lebrice): Getting a weird \"CUDA error: out of memory\" RuntimeError during\n",
-    "    # JIT, which can be \"fixed\" by first creating a dummy cuda tensor!\n",
-    "    v = torch.ones(1, device=\"cuda\")\n",
-    "\n",
-    "CUDA = torch.cuda.is_available()\n",
     "\n",
     "env = gym.make(\"brax_halfcheetah-v0\", batch_size=batch_size)\n",
     "tick(\"Creating the env\")\n",
@@ -120,17 +140,17 @@
     "    tick()\n",
     "\n",
     "\n",
-    "elapsed_times = [times[i+1] - times[i] for i in range(len(times)-1)]\n",
+    "elapsed_times = [_times[i+1] - _times[i] for i in range(len(_times)-1)]\n",
     "\n",
-    "time_for_n_steps_avg = np.mean(elapsed_times)\n",
-    "time_for_n_steps_std = np.std(elapsed_times)\n",
+    "time_per_step_avg = np.mean(elapsed_times)\n",
+    "time_per_step_std = np.std(elapsed_times)\n",
     "\n",
-    "frequency =  1 / time_for_n_steps_avg\n",
+    "frequency =  1 / time_per_step_avg\n",
     "effective_frequency = (batch_size or 1) * frequency\n",
     "\n",
     "print(f\"Device used: {obs.device}\")\n",
     "print(f\"Number of parallel environments: {batch_size}\")\n",
-    "print(f\"Average time per batched step:  {time_for_n_steps_avg} ± {time_for_n_steps_std} seconds\")\n",
+    "print(f\"Average time per batched step:  {time_per_step_avg} ± {time_per_step_std} seconds\")\n",
     "print(f\"Frequency (after first two steps): ~{frequency:.3f} batched steps / second.\")\n",
     "print(f\"Effective Frequency (after first two steps): ~{effective_frequency:.3f} steps / second.\")"
    ],
@@ -139,18 +159,18 @@
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "Time for Creating the env: 0.0038437843322753906\n",
-      "Time for Wrapping the env: 0.0038437843322753906\n",
-      "Time for First reset: 0.0038437843322753906\n",
-      "Time for First step: 0.0038437843322753906\n",
-      "Time for Second step: 0.0038437843322753906\n"
+      "Time for Creating the env: 10.294265508651733\n",
+      "Time for Wrapping the env: 0.00015664100646972656\n",
+      "Time for First reset: 3.978239059448242\n",
+      "Time for First step: 2.3907294273376465\n",
+      "Time for Second step: 2.2790026664733887\n"
      ]
     },
     {
      "output_type": "stream",
      "name": "stderr",
      "text": [
-      "100%|██████████| 1024000/1024000 [00:03<00:00, 289150.23it/s]"
+      "100%|██████████| 1024000/1024000 [00:03<00:00, 296106.44it/s]"
      ]
     },
     {
@@ -159,9 +179,9 @@
      "text": [
       "Device used: cuda:0\n",
       "Number of parallel environments: 1024\n",
-      "Average time per batched step:  0.0039951517013366335 ± 0.00026153933497828803 seconds\n",
-      "Frequency: ~250.303 batched steps / second.\n",
-      "Effective Frequency: ~256310.668 steps / second.\n"
+      "Average time per batched step:  0.0034599435329437257 ± 0.00036434224775974217 seconds\n",
+      "Frequency (after first two steps): ~289.022 batched steps / second.\n",
+      "Effective Frequency (after first two steps): ~295958.587 steps / second.\n"
      ]
     },
     {

--- a/notebooks/gym_pytorch.ipynb
+++ b/notebooks/gym_pytorch.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/to_torch/notebooks/pytorch.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/master/notebooks/gym_pytorch.ipynb)"
    ],
    "metadata": {}
   },

--- a/notebooks/gym_pytorch.ipynb
+++ b/notebooks/gym_pytorch.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/master/notebooks/gym_pytorch.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/notebooks/gym_pytorch.ipynb)"
    ],
    "metadata": {}
   },


### PR DESCRIPTION
- Add JaxToTorchWrapper in to_torch.py, which converts DeviceArrays into
  PyTorch Tensors without transfering them to CPU.
- Add "backend" argument to `GymWrapper` constructor.

Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>