### PR TITLE
Fix braxlines open in colab URLs

### DIFF
--- a/notebooks/braxlines/experiment_sweep.ipynb
+++ b/notebooks/braxlines/experiment_sweep.ipynb
@@ -23,7 +23,7 @@
         "# This is formatted as code\n",
         "```\n",
         "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/notebooks/braxlines/vgcrl.ipynb)"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/notebooks/braxlines/experiment_sweep.ipynb)"
       ]
     },
     {

--- a/notebooks/braxlines/experiment_sweep.ipynb
+++ b/notebooks/braxlines/experiment_sweep.ipynb
@@ -23,7 +23,7 @@
         "# This is formatted as code\n",
         "```\n",
         "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/experimental/braxlines/notebooks/vgcrl.ipynb)"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/notebooks/braxlines/vgcrl.ipynb)"
       ]
     },
     {

--- a/notebooks/braxlines/experiment_viewer.ipynb
+++ b/notebooks/braxlines/experiment_viewer.ipynb
@@ -23,7 +23,7 @@
         "# This is formatted as code\n",
         "```\n",
         "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/notebooks/braxlines/vgcrl.ipynb)"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/notebooks/braxlines/experiment_viewer.ipynb)"
       ]
     },
     {

--- a/notebooks/braxlines/experiment_viewer.ipynb
+++ b/notebooks/braxlines/experiment_viewer.ipynb
@@ -23,7 +23,7 @@
         "# This is formatted as code\n",
         "```\n",
         "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/experimental/braxlines/notebooks/vgcrl.ipynb)"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/notebooks/braxlines/vgcrl.ipynb)"
       ]
     },
     {

--- a/notebooks/braxlines/irl_smm.ipynb
+++ b/notebooks/braxlines/irl_smm.ipynb
@@ -29,7 +29,7 @@
         "# This is formatted as code\n",
         "```\n",
         "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/experimental/braxlines/notebooks/irl_smm.ipynb)"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/notebooks/braxlines/irl_smm.ipynb)"
       ]
     },
     {

--- a/notebooks/braxlines/vgcrl.ipynb
+++ b/notebooks/braxlines/vgcrl.ipynb
@@ -27,7 +27,7 @@
         "# This is formatted as code\n",
         "```\n",
         "\n",
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/experimental/braxlines/notebooks/vgcrl.ipynb)"
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/notebooks/braxlines/vgcrl.ipynb)"
       ]
     },
     {


### PR DESCRIPTION
Couldn't open the new braxlines 'in colab' due to structural file changes. Added the correct collar URLs to the braxlins enotebooks.