### PR TITLE
Add spectral normalization for braxlines

### DIFF
--- a/brax/experimental/braxlines/vgcrl/train.py
+++ b/brax/experimental/braxlines/vgcrl/train.py
@@ -67,6 +67,7 @@ def train(train_job_params: Dict[str, Any],
   seed = config.pop('seed', 0)
   diayn_num_skills = config.pop('diayn_num_skills', 8)
   disc_update_ratio = config.pop('disc_update_ratio', 1.0)
+  spectral_norm = config.pop('spectral_norm', False)
   ppo_params = dict(
       num_timesteps=int(5e7),
       reward_scaling=10,
@@ -97,7 +98,8 @@ def train(train_job_params: Dict[str, Any],
       obs_indices=obs_indices,
       scale=env_scale,
       diayn_num_skills=diayn_num_skills,
-      logits_clip_range=logits_clip_range)
+      logits_clip_range=logits_clip_range,
+      spectral_norm=spectral_norm)
   disc = disc_fn(env=base_env, normalize_obs=normalize_obs_for_disc)
   extra_params = disc.init_model(rng=jax.random.PRNGKey(seed=seed))
   env_fn = vgcrl_utils.create_fn(env_name=env_name, disc=disc)

--- a/brax/training/networks.py
+++ b/brax/training/networks.py
@@ -93,7 +93,6 @@ def make_model(layer_sizes: Sequence[int],
   Returns:
     a model
   """
-  module = MLP(layer_sizes=layer_sizes, activation=activation)
   dummy_obs = jnp.zeros((1, obs_size))
   if spectral_norm:
     module = SNMLP(layer_sizes=layer_sizes, activation=activation)

--- a/brax/training/spectral_norm.py
+++ b/brax/training/spectral_norm.py
@@ -20,7 +20,7 @@ Reference:
     - https://arxiv.org/abs/1802.05957
     - https://github.com/deepmind/dm-haiku/blob/main/haiku/_src/spectral_norm.py
 """
-from typing import (Any, Callable, Tuple)
+from typing import Any, Callable, Tuple
 
 from jax import lax
 import jax.numpy as jnp
@@ -29,14 +29,10 @@ from flax import linen
 from flax.linen.initializers import lecun_normal, normal, zeros
 
 
-default_kernel_init = lecun_normal()
-
 PRNGKey = Any
 Array = Any
 Shape = Tuple[int]
 Dtype = Any
-
-_no_init = lambda rng, shape: ()
 
 
 def _l2_normalize(x, axis=None, eps=1e-12):
@@ -74,7 +70,7 @@ class SNDense(linen.Module):
   use_bias: bool = True
   dtype: Any = jnp.float32
   precision: Any = None
-  kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = default_kernel_init
+  kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = lecun_normal()
   bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = zeros
   eps: float = 1e-4
   n_steps: int = 1
@@ -100,7 +96,7 @@ class SNDense(linen.Module):
     # Handle scalars.
     if kernel.ndim <= 1:
       raise ValueError("Spectral normalization is not well defined for "
-                      "scalar inputs.")
+                       "scalar inputs.")
     # Handle higher-order tensors.
     elif kernel.ndim > 2:
       kernel = jnp.reshape(kernel, [-1, kernel.shape[-1]])

--- a/brax/training/spectral_norm.py
+++ b/brax/training/spectral_norm.py
@@ -1,0 +1,133 @@
+# Copyright 2021 The Brax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Flax-style Dense module with Spectral Normalization.
+
+Reference:
+  Dense: https://github.com/google/flax/blob/main/flax/linen/linear.py
+  Spectral Normalization:
+    - https://arxiv.org/abs/1802.05957
+    - https://github.com/deepmind/dm-haiku/blob/main/haiku/_src/spectral_norm.py
+"""
+from typing import (Any, Callable, Tuple)
+
+from jax import lax
+import jax.numpy as jnp
+
+from flax import linen
+from flax.linen.initializers import lecun_normal, normal, zeros
+
+
+default_kernel_init = lecun_normal()
+
+PRNGKey = Any
+Array = Any
+Shape = Tuple[int]
+Dtype = Any
+
+_no_init = lambda rng, shape: ()
+
+
+def _l2_normalize(x, axis=None, eps=1e-12):
+  """Normalizes along dimension `axis` using an L2 norm.
+  This specialized function exists for numerical stability reasons.
+  Args:
+    x: An input ndarray.
+    axis: Dimension along which to normalize, e.g. `1` to separately normalize
+      vectors in a batch. Passing `None` views `t` as a flattened vector when
+      calculating the norm (equivalent to Frobenius norm).
+    eps: Epsilon to avoid dividing by zero.
+  Returns:
+    An array of the same shape as 'x' L2-normalized along 'axis'.
+  """
+  return x * lax.rsqrt((x * x).sum(axis=axis, keepdims=True) + eps)
+
+
+class SNDense(linen.Module):
+  """A linear transformation applied over the last dimension of the input
+  with spectral normalization (https://arxiv.org/abs/1802.05957).
+
+  Attributes:
+    features: the number of output features.
+    use_bias: whether to add a bias to the output (default: True).
+    dtype: the dtype of the computation (default: float32).
+    precision: numerical precision of the computation see `jax.lax.Precision`
+      for details.
+    kernel_init: initializer function for the weight matrix.
+    bias_init: initializer function for the bias.
+    eps: The constant used for numerical stability.
+    n_steps: How many steps of power iteration to perform to approximate the
+      singular value of the input.
+  """
+  features: int
+  use_bias: bool = True
+  dtype: Any = jnp.float32
+  precision: Any = None
+  kernel_init: Callable[[PRNGKey, Shape, Dtype], Array] = default_kernel_init
+  bias_init: Callable[[PRNGKey, Shape, Dtype], Array] = zeros
+  eps: float = 1e-4
+  n_steps: int = 1
+
+  @linen.compact
+  def __call__(self, inputs: Array) -> Array:
+    """Applies a linear transformation to the inputs along the last dimension.
+
+    Args:
+      inputs: The nd-array to be transformed.
+
+    Returns:
+      The transformed input.
+    """
+    inputs = jnp.asarray(inputs, self.dtype)
+    kernel = self.param('kernel',
+                        self.kernel_init,
+                        (inputs.shape[-1], self.features))
+    kernel = jnp.asarray(kernel, self.dtype)
+
+    """for spectral normalization"""
+    kernel_shape = kernel.shape
+    # Handle scalars.
+    if kernel.ndim <= 1:
+      raise ValueError("Spectral normalization is not well defined for "
+                      "scalar inputs.")
+    # Handle higher-order tensors.
+    elif kernel.ndim > 2:
+      kernel = jnp.reshape(kernel, [-1, kernel.shape[-1]])
+    key = self.make_rng('sing_vec')
+    u0_state = self.variable('sing_vec', 'u0', normal(stddev=1.), key, (1, kernel.shape[-1]))
+    u0 = u0_state.value
+
+    # Power iteration for the weight's singular value.
+    for _ in range(self.n_steps):
+      v0 = _l2_normalize(jnp.matmul(u0, kernel.transpose([1, 0])), eps=self.eps)
+      u0 = _l2_normalize(jnp.matmul(v0, kernel), eps=self.eps)
+
+    u0 = lax.stop_gradient(u0)
+    v0 = lax.stop_gradient(v0)
+
+    sigma = jnp.matmul(jnp.matmul(v0, kernel), jnp.transpose(u0))[0, 0]
+
+    kernel /= sigma
+    kernel = kernel.reshape(kernel_shape)
+
+    u0_state.value = u0
+
+    y = lax.dot_general(inputs, kernel,
+                        (((inputs.ndim - 1,), (0,)), ((), ())),
+                        precision=self.precision)
+    if self.use_bias:
+      bias = self.param('bias', self.bias_init, (self.features,))
+      bias = jnp.asarray(bias, self.dtype)
+      y = y + bias
+    return y

--- a/notebooks/braxlines/experiment_sweep.ipynb
+++ b/notebooks/braxlines/experiment_sweep.ipynb
@@ -2,20 +2,17 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ssCOanHc8JH_"
-      },
       "source": [
         "# Sweep Training\n",
         "\n",
         "We can perform hyperparameter sweep directly on Colab."
-      ]
+      ],
+      "metadata": {
+        "id": "ssCOanHc8JH_"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "VYe1kc3a4Oxc"
-      },
       "source": [
         "\n",
         "\n",
@@ -24,19 +21,18 @@
         "```\n",
         "\n",
         "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/experimental/braxlines/notebooks/vgcrl.ipynb)"
-      ]
+      ],
+      "metadata": {
+        "id": "VYe1kc3a4Oxc"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "rlVNS8JstMRr"
-      },
-      "outputs": [],
       "source": [
         "#@title Colab setup and imports\n",
         "#@markdown ## ⚠️ PLEASE NOTE:\n",
-        "#@markdown This colab runs best using a TPU runtime.  From the Colab menu, choose Runtime \u003e Change Runtime Type, then select **'TPU'** in the dropdown.\n",
+        "#@markdown This colab runs best using a TPU runtime.  From the Colab menu, choose Runtime > Change Runtime Type, then select **'TPU'** in the dropdown.\n",
         "\n",
         "#@markdown See [config_utils.py](https://github.com/google/brax/blob/main/brax/experimental/braxlines/common/config_utils.py)\n",
         "#@markdown for the configuration format.\n",
@@ -77,6 +73,7 @@
         "      algo_name = ['gcrl', 'diayn'],\n",
         "      seed = [0],\n",
         "      normalize_obs_for_disc = [False],\n",
+        "      spectral_norm = [True],\n",
         "      ppo_params = dict(\n",
         "        num_timesteps=int(2e8),\n",
         "        reward_scaling=10,\n",
@@ -96,7 +93,7 @@
         "\n",
         "prefix_keys = config_utils.list_keys_to_expand(config)\n",
         "for c, p in zip(config, prefix_keys):\n",
-        "  c.update(dict(prefix_keys=p)) \n",
+        "  c.update(dict(prefix_keys=p))\n",
         "config_count= config_utils.count_configuration(config)\n",
         "start_count= max(start_count, 0)\n",
         "end_count = min(end_count, sum(config_count))\n",
@@ -105,15 +102,15 @@
         "print(f'Set start_count={start_count}, end_count={end_count}')\n",
         "print(f'Set prefix_keys={prefix_keys}')\n",
         "print(f'Set output_dir={output_path}')"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "rlVNS8JstMRr"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "NaJDZqhCLovU"
-      },
-      "outputs": [],
       "source": [
         "#@title Launch experiments\n",
         "\n",
@@ -135,7 +132,11 @@
         "    train.train(c, output_dir=output_dir, return_dict=return_dict)\n",
         "  except Error as e:\n",
         "    print(f'[{i+1}/{sum(config_count)}] FAILED experiment {e}')"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "NaJDZqhCLovU"
+      }
     }
   ],
   "metadata": {
@@ -168,5 +169,5 @@
     }
   },
   "nbformat": 4,
-  "nbformat_minor": 0
+  "nbformat_minor": 2
 }

--- a/notebooks/braxlines/experiment_viewer.ipynb
+++ b/notebooks/braxlines/experiment_viewer.ipynb
@@ -2,20 +2,17 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ssCOanHc8JH_"
-      },
       "source": [
         "# Experiment Viewer\n",
         "\n",
         "We can visualize hyperparameter sweep result directly on Colab."
-      ]
+      ],
+      "metadata": {
+        "id": "ssCOanHc8JH_"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "VYe1kc3a4Oxc"
-      },
       "source": [
         "\n",
         "\n",
@@ -24,17 +21,19 @@
         "```\n",
         "\n",
         "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/experimental/braxlines/notebooks/vgcrl.ipynb)"
-      ]
+      ],
+      "metadata": {
+        "id": "VYe1kc3a4Oxc"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "rlVNS8JstMRr"
-      },
-      "outputs": [],
       "source": [
         "# @title Colab setup and imports\n",
+        "import os\n",
+        "from IPython.display import clear_output\n",
+        "\n",
         "try:\n",
         "  import brax\n",
         "except ImportError:\n",
@@ -50,15 +49,15 @@
         "pattern = f'{output_path}/**/training_curves.csv'\n",
         "csv_files = file.Glob(pattern)\n",
         "print(f'Found {len(csv_files)} files matching {pattern}')\n"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "rlVNS8JstMRr"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "9Mn_Iml-w71b"
-      },
-      "outputs": [],
       "source": [
         "# @title Load data\n",
         "data = {}\n",
@@ -66,15 +65,15 @@
         "  key = os.path.basename(os.path.dirname(csv_file))\n",
         "  print(f'[{i+1}/{len(csv_files)}]')\n",
         "  data[key] = logger_utils.parse_csv(csv_file, verbose=True)"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "9Mn_Iml-w71b"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "yEwJnB4F3sYk"
-      },
-      "outputs": [],
       "source": [
         "# @title Plot data\n",
         "import matplotlib.pyplot as plt\n",
@@ -101,7 +100,11 @@
         "ax.legend()\n",
         "fig.tight_layout()\n",
         "plt.show()"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "yEwJnB4F3sYk"
+      }
     }
   ],
   "metadata": {
@@ -138,5 +141,5 @@
     }
   },
   "nbformat": 4,
-  "nbformat_minor": 0
+  "nbformat_minor": 2
 }

--- a/notebooks/braxlines/vgcrl.ipynb
+++ b/notebooks/braxlines/vgcrl.ipynb
@@ -2,9 +2,6 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "ssCOanHc8JH_"
-      },
       "source": [
         "# Training Goal-Conditioned and Unsupervised RL Agents in Brax\n",
         "\n",
@@ -13,13 +10,13 @@
         "This provides a bare bone implementation based on minimal modifications to the\n",
         "baseline [PPO](https://github.com/google/brax/blob/main/brax/training/ppo.py),\n",
         "enabling training in a few minutes. More features, tunings, and benchmarked results will be added soon."
-      ]
+      ],
+      "metadata": {
+        "id": "ssCOanHc8JH_"
+      }
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "VYe1kc3a4Oxc"
-      },
       "source": [
         "\n",
         "\n",
@@ -28,19 +25,18 @@
         "```\n",
         "\n",
         "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/google/brax/blob/main/experimental/braxlines/notebooks/vgcrl.ipynb)"
-      ]
+      ],
+      "metadata": {
+        "id": "VYe1kc3a4Oxc"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "rlVNS8JstMRr"
-      },
-      "outputs": [],
       "source": [
         "#@title Colab setup and imports\n",
         "#@markdown ## ⚠️ PLEASE NOTE:\n",
-        "#@markdown This colab runs best using a TPU runtime.  From the Colab menu, choose Runtime \u003e Change Runtime Type, then select **'TPU'** in the dropdown.\n",
+        "#@markdown This colab runs best using a TPU runtime.  From the Colab menu, choose Runtime > Change Runtime Type, then select **'TPU'** in the dropdown.\n",
         "\n",
         "from datetime import datetime\n",
         "import functools\n",
@@ -70,15 +66,15 @@
         "if \"COLAB_TPU_ADDR\" in os.environ:\n",
         "  from jax.tools import colab_tpu\n",
         "  colab_tpu.setup_tpu()"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "rlVNS8JstMRr"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "gh4QsRPnX770"
-      },
-      "outputs": [],
       "source": [
         "#@title Define experiment parameters\n",
         "\n",
@@ -118,6 +114,7 @@
         "normalize_obs_for_disc = False  # @param {'type': 'boolean'}\n",
         "seed =   0# @param {type: 'integer'}\n",
         "diayn_num_skills = 8  # @param {type: 'integer'}\n",
+        "spectral_norm = True  # @param {type: 'boolean'}\n",
         "output_path = None  # @param {'type': 'raw'}\n",
         "output_path = output_path.format(\n",
         "    date=datetime.now().strftime('%Y%m%d'),\n",
@@ -125,15 +122,15 @@
         "    env_scale=env_scale,\n",
         "    env_name=env_name,\n",
         "    algo_name=algo_name) if output_path else None"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "gh4QsRPnX770"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "NaJDZqhCLovU"
-      },
-      "outputs": [],
       "source": [
         "# @title Visualizing Brax environments\n",
         "# Create baseline environment to get observation specs\n",
@@ -147,7 +144,8 @@
         "                   obs_indices=obs_indices,\n",
         "                   scale=env_scale,\n",
         "                   diayn_num_skills = diayn_num_skills,\n",
-        "                   logits_clip_range=logits_clip_range)\n",
+        "                   logits_clip_range=logits_clip_range,\n",
+        "                   spectral_norm=spectral_norm)\n",
         "disc = disc_fn(env=base_env, normalize_obs=normalize_obs_for_disc)\n",
         "extra_params = disc.init_model(rng=jax.random.PRNGKey(seed=seed))\n",
         "env_fn = vgcrl_utils.create_fn(env_name=env_name, disc=disc)\n",
@@ -158,15 +156,15 @@
         "state = jit_env_reset(rng=jax.random.PRNGKey(seed=seed))\n",
         "clear_output()  # clear out jax.lax warning before rendering\n",
         "HTML(html.render(env.sys, [state.qp]))"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "NaJDZqhCLovU"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "4vgMSWODfyMC"
-      },
-      "outputs": [],
       "source": [
         "#@title Training\n",
         "num_timesteps_multiplier = 4  # @param {type: 'integer'}\n",
@@ -217,7 +215,7 @@
         "    plotdata[key]['x'] += [num_steps]\n",
         "    plotdata[key]['y'] += [v]\n",
         "  # the first step does not include losses\n",
-        "  if num_steps \u003e 0:\n",
+        "  if num_steps > 0:\n",
         "    tab.add(num_steps=num_steps, **metrics)\n",
         "    tab.dump()\n",
         "  clear_output(wait=True)\n",
@@ -239,15 +237,15 @@
         "\n",
         "print(f'time to jit: {times[1] - times[0]}')\n",
         "print(f'time to train: {times[-1] - times[1]}')"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "4vgMSWODfyMC"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "RNMLEyaTspEM"
-      },
-      "outputs": [],
       "source": [
         "#@title Visualizing a trajectory of the learned inference function\n",
         "#@markdown If `z_value` is `None`, sample `z`, else fix `z` to `z_value`.\n",
@@ -274,15 +272,15 @@
         "    output_name=f'video_z_{z_value}',\n",
         ")\n",
         "HTML(html.render(env.sys, [state.qp for state in states]))"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "RNMLEyaTspEM"
+      }
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "p5eWOxg7RmQQ"
-      },
-      "outputs": [],
       "source": [
         "#@title Visualizing skills of the learned inference function in 2D plot\n",
         "num_samples_per_z = 5  # @param {type: 'integer'}\n",
@@ -304,7 +302,11 @@
         "    time_last_n=time_last_n,\n",
         "    seed=eval_seed)\n",
         "plt.show()"
-      ]
+      ],
+      "outputs": [],
+      "metadata": {
+        "id": "p5eWOxg7RmQQ"
+      }
     }
   ],
   "metadata": {
@@ -333,5 +335,5 @@
     }
   },
   "nbformat": 4,
-  "nbformat_minor": 0
+  "nbformat_minor": 2
 }


### PR DESCRIPTION
I added a spectral normalization feature for braxlines.

Spectral normalization improves the discriminator in [VGCRL](https://arxiv.org/abs/2106.01404). My implementation seems to work successfully in DIAYN/Ant.

**w/o SN**
- Training Curves
![image](https://user-images.githubusercontent.com/33809149/130622295-aded8ed7-3d9a-4dae-909f-64dd817d2051.png)
- Skills visualization
![image](https://user-images.githubusercontent.com/33809149/130622551-4e2c5d96-cf09-4dbf-8756-a8c19449d66b.png)


**w/ SN**
- Training Curves
![image](https://user-images.githubusercontent.com/33809149/130623935-ddf71692-9dce-4b5a-aefd-493fd82790f6.png)
- Skills visualization
![image](https://user-images.githubusercontent.com/33809149/130623979-fd555faa-03fa-46ff-8aa5-e1bbc63eac1e.png)
