### PR TITLE
Enable per-collider friction specification

### DIFF
--- a/brax/physics/colliders.py
+++ b/brax/physics/colliders.py
@@ -30,6 +30,28 @@ from brax.physics.base import P, QP, euler_to_quat, vec_to_np, take
 from brax.physics.math import safe_norm
 
 
+@struct.dataclass
+class Collider:
+  """
+  A Collider contains information pertaining to collision such as friction and elasticity.
+  """
+  idx: jnp.ndarray
+  friction: jnp.ndarray
+
+  @classmethod
+  def from_config(cls, config: config_pb2.Config) -> 'Collider':
+    """Returns Collider from a brax config."""
+    colliders = []
+    for idx, body in enumerate(config.bodies):
+      for col in body.colliders:
+        colliders.append(
+          cls(
+            idx=jnp.array(idx),
+            friction=col.friction if col.HasField("friction") else config.friction
+          ))
+    return jax.tree_multimap((lambda *args: jnp.stack(args)), *colliders)
+
+
 class BoxPlane:
   """A collision between a box corner and a static plane."""
 
@@ -60,8 +82,11 @@ class BoxPlane:
         corners.append(corner)
 
     body = bodies.Body.from_config(config)
+    col = Collider.from_config(config)
     self.box = take(body, jnp.array(box_idxs))
+    self.box_col = take(col, jnp.array(box_idxs))
     self.plane = take(body, jnp.array(plane_idxs))
+    self.plane_col = take(col, jnp.array(plane_idxs))
     self.corner = jnp.array(corners)
 
   def apply(self, qp: QP, dt: float) -> P:
@@ -83,17 +108,17 @@ class BoxPlane:
       return P(jnp.zeros_like(qp.vel), jnp.zeros_like(qp.ang))
 
     @jax.vmap
-    def apply(box, corner, qp_box, qp_plane):
+    def apply(box, col, corner, qp_box, qp_plane):
       pos, vel = math.to_world(qp_box, corner)
       normal = math.rotate(jnp.array([0.0, 0.0, 1.0]), qp_plane.rot)
       penetration = jnp.dot(pos - qp_plane.pos, normal)
-      dp = _collide(self.config, box, qp_box, pos, vel, normal, penetration, dt)
+      dp = _collide(self.config, box, col, qp_box, pos, vel, normal, penetration, dt)
       collided = jnp.where(penetration < 0., 1., 0.)
       return dp, collided
 
     qp_box = take(qp, self.box.idx)
     qp_plane = take(qp, self.plane.idx)
-    dp, colliding = apply(self.box, self.corner, qp_box, qp_plane)
+    dp, colliding = apply(self.box, self.box_col, self.corner, qp_box, qp_plane)
 
     # collapse/sum across all corners
     num_bodies = len(self.config.bodies)
@@ -154,8 +179,11 @@ class BoxHeightMap:
         meshSizes.append(meshSize)
 
     body = bodies.Body.from_config(config)
+    col = Collider.from_config(config)
     self.box = take(body, jnp.array(box_idxs))
+    self.box_col = take(col, jnp.array(box_idxs))
     self.heightMap = take(body, jnp.array(heightMap_idxs))
+    self.heightMap_col = take(col, jnp.array(heightMap_idxs))
     self.corner = jnp.array(corners)
     self.size = jnp.array(sizes)
     self.meshSize = jnp.array(meshSizes)
@@ -179,7 +207,7 @@ class BoxHeightMap:
       return P(jnp.zeros_like(qp.vel), jnp.zeros_like(qp.ang))
 
     @jax.vmap
-    def apply(box, corner, qp_box, qp_heightMap, size, meshSize, heights):
+    def apply(box, col, corner, qp_box, qp_heightMap, size, meshSize, heights):
       world_pos, vel = math.to_world(qp_box, corner)
 
       pos = math.inv_rotate(world_pos - qp_heightMap.pos, qp_heightMap.rot)
@@ -220,14 +248,14 @@ class BoxHeightMap:
       ])
       penetration = jnp.dot(pos - pos_0, normal)
 
-      dp = _collide(self.config, box, qp_box, pos, vel, rotated_normal,
+      dp = _collide(self.config, box, col, qp_box, pos, vel, rotated_normal,
                     penetration, dt)
       collided = jnp.where(penetration < 0., 1., 0.)
       return dp, collided
 
     qp_box = take(qp, self.box.idx)
     qp_heightMap = take(qp, self.heightMap.idx)
-    dp, colliding = apply(self.box, self.corner, qp_box, qp_heightMap,
+    dp, colliding = apply(self.box, self.box_col, self.corner, qp_box, qp_heightMap,
                           self.size, self.meshSize, self.heights)
 
     # collapse/sum across all corners
@@ -282,8 +310,11 @@ class CapsulePlane:
         cap_radius.append(capsule.radius)
 
     body = bodies.Body.from_config(config)
+    col = Collider.from_config(config)
     self.cap = take(body, jnp.array(cap_idx))
+    self.cap_col = take(col, jnp.array(cap_idx))
     self.plane = take(body, jnp.array(plane_idx))
+    self.plane_col = take(col, jnp.array(plane_idx))
     self.cap_end = jnp.array(cap_end)
     self.cap_radius = jnp.array(cap_radius)
 
@@ -306,7 +337,7 @@ class CapsulePlane:
       return P(jnp.zeros_like(qp.vel), jnp.zeros_like(qp.ang))
 
     @jax.vmap
-    def apply(cap, cap_end, radius, qp_cap, qp_plane):
+    def apply(cap, col, cap_end, radius, qp_cap, qp_plane):
       cap_end_world = qp_cap.pos + math.rotate(cap_end, qp_cap.rot)
       normal = math.rotate(jnp.array([0.0, 0.0, 1.0]), qp_plane.rot)
       pos = cap_end_world - normal * radius
@@ -315,13 +346,13 @@ class CapsulePlane:
       vel = qp_cap.vel + rvel
 
       penetration = jnp.dot(pos - qp_plane.pos, normal)
-      dp = _collide(self.config, cap, qp_cap, pos, vel, normal, penetration, dt)
+      dp = _collide(self.config, cap, col, qp_cap, pos, vel, normal, penetration, dt)
       colliding = jnp.where(penetration < 0., 1., 0.)
       return dp, colliding
 
     qp_cap = take(qp, self.cap.idx)
     qp_plane = take(qp, self.plane.idx)
-    dp, colliding = apply(self.cap, self.cap_end, self.cap_radius, qp_cap,
+    dp, colliding = apply(self.cap, self.cap_col, self.cap_end, self.cap_radius, qp_cap,
                           qp_plane)
 
     # sum across both contact points
@@ -343,6 +374,7 @@ class CapsuleCapsule:
   @struct.dataclass
   class Capsule:
     body: bodies.Body
+    col: Collider
     radius: jnp.ndarray
     end: jnp.ndarray
 
@@ -368,12 +400,17 @@ class CapsuleCapsule:
       ends.append((cap_end(col_a), cap_end(col_b)))
 
     body = bodies.Body.from_config(config)
+    col = Collider.from_config(config)
+    cap_a_idxs = jnp.array([a for a, _ in body_idxs])
+    cap_b_idxs = jnp.array([b for _, b in body_idxs])
     self.cap_a = CapsuleCapsule.Capsule(
-        body=take(body, jnp.array([a for a, _ in body_idxs])),
+        body=take(body, cap_a_idxs),
+        col=take(col, cap_a_idxs),
         radius=jnp.array([a for a, _ in radii]),
         end=jnp.array([a for a, _ in ends]))
     self.cap_b = CapsuleCapsule.Capsule(
-        body=take(body, jnp.array([b for _, b in body_idxs])),
+        body=take(body, cap_b_idxs),
+        col=take(col, cap_b_idxs),
         radius=jnp.array([b for _, b in radii]),
         end=jnp.array([b for _, b in ends]))
 
@@ -427,8 +464,8 @@ class CapsuleCapsule:
       penetration = dist - cap_a.radius - cap_b.radius
       pos_c = (bestA + bestB) / 2.
 
-      dp_a, dp_b = _collide_pair(self.config, cap_a.body, cap_b.body, qp_a,
-                                 qp_b, pos_c, collision_normal, penetration, dt)
+      dp_a, dp_b = _collide_pair(self.config, cap_a.body, cap_b.body, cap_a.col, cap_b.col, qp_a, qp_b, pos_c,
+                                 collision_normal, penetration, dt)
       return dp_a, dp_b
 
     qp_a = take(qp, self.cap_a.body.idx)
@@ -485,7 +522,7 @@ def _find_body_pairs(
   return ret
 
 
-def _collide(config: config_pb2.Config, body: bodies.Body, qp: QP,
+def _collide(config: config_pb2.Config, body: bodies.Body, col: Collider, qp: QP,
              pos_c: jnp.ndarray, vel_c: jnp.ndarray, normal_c: jnp.ndarray,
              penetration: float, dt: float) -> P:
   """Calculates velocity change due to a collision.
@@ -518,10 +555,10 @@ def _collide(config: config_pb2.Config, body: bodies.Body, qp: QP,
 
   # apply drag due to friction acting parallel to the surface contact
   rel_vel_d = vel_c - normal_rel_vel * normal_c
-  impulse_d = math.safe_norm(rel_vel_d) / ((1. / (body.mass)) + ang)
+  impulse_d = math.safe_norm(rel_vel_d) / ((1. / body.mass) + ang)
   # drag magnitude cannot exceed max friction
-  impulse_d = jnp.where(impulse_d < config.friction * impulse, impulse_d,
-                        config.friction * impulse)
+  impulse_d = jnp.where(impulse_d < col.friction * impulse, impulse_d,
+                        col.friction * impulse)
   dir_d = rel_vel_d / (1e-6 + math.safe_norm(rel_vel_d))
   dp_d = body.impulse(qp, -impulse_d * dir_d, pos_c)
 
@@ -539,10 +576,9 @@ def _collide(config: config_pb2.Config, body: bodies.Body, qp: QP,
   return dp_n * colliding_n + dp_d * colliding_d * 2.0
 
 
-def _collide_pair(config: config_pb2.Config, body_a: bodies.Body,
-                  body_b: bodies.Body, qp_a: QP, qp_b: QP, pos_c: jnp.ndarray,
-                  normal_c: jnp.ndarray, penetration: float,
-                  dt: float) -> Tuple[P, P]:
+def _collide_pair(config: config_pb2.Config, body_a: bodies.Body, body_b: bodies.Body,
+                  col_a: Collider, col_b: Collider, qp_a: QP, qp_b: QP,
+                  pos_c: jnp.ndarray, normal_c: jnp.ndarray, penetration: float, dt: float) -> Tuple[P, P]:
   """Calculates velocity change due to a collision.
 
   Args:
@@ -558,6 +594,8 @@ def _collide_pair(config: config_pb2.Config, body_a: bodies.Body,
 
   Returns:
     dP: The impulse on this body result from the collision.
+    :param col_a:
+    :param col_b:
   """
   # TODO: possibly refactor into single collide fn?
   rel_pos_a = pos_c - qp_a.pos
@@ -588,11 +626,13 @@ def _collide_pair(config: config_pb2.Config, body_a: bodies.Body,
   impulse_d = math.safe_norm(rel_vel_d) / ((1. / body_a.mass) +
                                            (1. / body_b.mass) + ang)
   # drag magnitude cannot exceed max friction
-  impulse_d = jnp.where(impulse_d < config.friction * impulse, impulse_d,
-                        config.friction * impulse)
+  impulse_d_a = jnp.where(impulse_d < col_a.friction * impulse, impulse_d,
+                        col_a.friction * impulse)
+  impulse_d_b = jnp.where(impulse_d < col_b.friction * impulse, impulse_d,
+                        col_b.friction * impulse)
   dir_d = rel_vel_d / (1e-6 + math.safe_norm(rel_vel_d))
-  dp_d_a = body_a.impulse(qp_a, impulse_d * dir_d, pos_c)
-  dp_d_b = body_b.impulse(qp_b, -impulse_d * dir_d, pos_c)
+  dp_d_a = body_a.impulse(qp_a, impulse_d_a * dir_d, pos_c)
+  dp_d_b = body_b.impulse(qp_b, -impulse_d_b * dir_d, pos_c)
 
   # apply collision normal if penetrating, approaching, and oriented correctly
   colliding_n = jnp.where(penetration < 0., 1., 0.)

--- a/brax/physics/config.proto
+++ b/brax/physics/config.proto
@@ -65,13 +65,15 @@ message Collider {
   Vector3 position = 1;
   // Rotation relative to parent body
   Vector3 rotation = 2;
+  // Friction coefficient
+  optional float friction = 3;
   // A collider may only be one type
   oneof type {
-    Box box = 3;
-    Plane plane = 4;
-    Sphere sphere = 5;
-    Capsule capsule = 6;
-    HeightMap heightMap = 7;
+    Box box = 4;
+    Plane plane = 5;
+    Sphere sphere = 6;
+    Capsule capsule = 7;
+    HeightMap heightMap = 8;
   }
 }
 

--- a/brax/physics/config_pb2.py
+++ b/brax/physics/config_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x19\x62rax/physics/config.proto\x12\x04\x62rax\"*\n\x07Vector3\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"W\n\x06\x46rozen\x12\x1f\n\x08position\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12\x0b\n\x03\x61ll\x18\x03 \x01(\x08\"\x83\x01\n\x04\x42ody\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\tcolliders\x18\x02 \x03(\x0b\x32\x0e.brax.Collider\x12\x1e\n\x07inertia\x18\x03 \x01(\x0b\x32\r.brax.Vector3\x12\x0c\n\x04mass\x18\x04 \x01(\x02\x12\x1c\n\x06\x66rozen\x18\x05 \x01(\x0b\x32\x0c.brax.Frozen\"\xcd\x03\n\x08\x43ollider\x12\x1f\n\x08position\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12!\n\x03\x62ox\x18\x03 \x01(\x0b\x32\x12.brax.Collider.BoxH\x00\x12%\n\x05plane\x18\x04 \x01(\x0b\x32\x14.brax.Collider.PlaneH\x00\x12\'\n\x06sphere\x18\x05 \x01(\x0b\x32\x15.brax.Collider.SphereH\x00\x12)\n\x07\x63\x61psule\x18\x06 \x01(\x0b\x32\x16.brax.Collider.CapsuleH\x00\x12-\n\theightMap\x18\x07 \x01(\x0b\x32\x18.brax.Collider.HeightMapH\x00\x1a&\n\x03\x42ox\x12\x1f\n\x08halfsize\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x1a\x07\n\x05Plane\x1a\x18\n\x06Sphere\x12\x0e\n\x06radius\x18\x01 \x01(\x02\x1a\x36\n\x07\x43\x61psule\x12\x0e\n\x06radius\x18\x01 \x01(\x02\x12\x0e\n\x06length\x18\x02 \x01(\x02\x12\x0b\n\x03\x65nd\x18\x03 \x01(\x05\x1a\'\n\tHeightMap\x12\x0c\n\x04size\x18\x01 \x01(\x02\x12\x0c\n\x04\x64\x61ta\x18\x02 \x03(\x02\x42\x06\n\x04type\"\xf7\x02\n\x05Joint\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tstiffness\x18\x02 \x01(\x02\x12\x0e\n\x06parent\x18\x03 \x01(\t\x12\r\n\x05\x63hild\x18\x04 \x01(\t\x12$\n\rparent_offset\x18\x05 \x01(\x0b\x32\r.brax.Vector3\x12#\n\x0c\x63hild_offset\x18\x06 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x07 \x01(\x0b\x32\r.brax.Vector3\x12\x17\n\x0f\x61ngular_damping\x18\x08 \x01(\x02\x12&\n\x0b\x61ngle_limit\x18\t \x03(\x0b\x32\x11.brax.Joint.Range\x12\x1b\n\x0elimit_strength\x18\n \x01(\x02H\x00\x88\x01\x01\x12\x1b\n\x0espring_damping\x18\x0b \x01(\x02H\x01\x88\x01\x01\x1a!\n\x05Range\x12\x0b\n\x03min\x18\x01 \x01(\x02\x12\x0b\n\x03max\x18\x02 \x01(\x02\x42\x11\n\x0f_limit_strengthB\x11\n\x0f_spring_damping\"\xa4\x01\n\x08\x41\x63tuator\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05joint\x18\x02 \x01(\t\x12\x10\n\x08strength\x18\x03 \x01(\x02\x12\'\n\x06torque\x18\x04 \x01(\x0b\x32\x15.brax.Actuator.TorqueH\x00\x12%\n\x05\x61ngle\x18\x05 \x01(\x0b\x32\x14.brax.Actuator.AngleH\x00\x1a\x08\n\x06Torque\x1a\x07\n\x05\x41ngleB\x06\n\x04type\"\xa0\x02\n\x0c\x44\x65\x66\x61ultState\x12-\n\x06\x61ngles\x18\x01 \x03(\x0b\x32\x1d.brax.DefaultState.JointAngle\x12\"\n\x03qps\x18\x02 \x03(\x0b\x32\x15.brax.DefaultState.QP\x1a\x38\n\nJointAngle\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1c\n\x05\x61ngle\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x1a\x82\x01\n\x02QP\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x03pos\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03rot\x18\x03 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03vel\x18\x04 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03\x61ng\x18\x05 \x01(\x0b\x32\r.brax.Vector3\"\xb1\x03\n\x06\x43onfig\x12\x1a\n\x06\x62odies\x18\x01 \x03(\x0b\x32\n.brax.Body\x12\x1b\n\x06joints\x18\x02 \x03(\x0b\x32\x0b.brax.Joint\x12!\n\tactuators\x18\x03 \x03(\x0b\x32\x0e.brax.Actuator\x12\x12\n\nelasticity\x18\x04 \x01(\x02\x12\x10\n\x08\x66riction\x18\x05 \x01(\x02\x12\x1e\n\x07gravity\x18\x06 \x01(\x0b\x32\r.brax.Vector3\x12\x18\n\x10velocity_damping\x18\x07 \x01(\x02\x12\x17\n\x0f\x61ngular_damping\x18\x08 \x01(\x02\x12\x15\n\rbaumgarte_erp\x18\t \x01(\x02\x12.\n\x0f\x63ollide_include\x18\n \x03(\x0b\x32\x15.brax.Config.NamePair\x12\n\n\x02\x64t\x18\x0b \x01(\x02\x12\x10\n\x08substeps\x18\x0c \x01(\x05\x12\x1c\n\x06\x66rozen\x18\r \x01(\x0b\x32\x0c.brax.Frozen\x12$\n\x08\x64\x65\x66\x61ults\x18\x0e \x03(\x0b\x32\x12.brax.DefaultState\x1a)\n\x08NamePair\x12\r\n\x05\x66irst\x18\x01 \x01(\t\x12\x0e\n\x06second\x18\x02 \x01(\tb\x06proto3'
+  serialized_pb=b'\n\x19\x62rax/physics/config.proto\x12\x04\x62rax\"*\n\x07Vector3\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"W\n\x06\x46rozen\x12\x1f\n\x08position\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12\x0b\n\x03\x61ll\x18\x03 \x01(\x08\"\x83\x01\n\x04\x42ody\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\tcolliders\x18\x02 \x03(\x0b\x32\x0e.brax.Collider\x12\x1e\n\x07inertia\x18\x03 \x01(\x0b\x32\r.brax.Vector3\x12\x0c\n\x04mass\x18\x04 \x01(\x02\x12\x1c\n\x06\x66rozen\x18\x05 \x01(\x0b\x32\x0c.brax.Frozen\"\xf1\x03\n\x08\x43ollider\x12\x1f\n\x08position\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12\x15\n\x08\x66riction\x18\x03 \x01(\x02H\x01\x88\x01\x01\x12!\n\x03\x62ox\x18\x04 \x01(\x0b\x32\x12.brax.Collider.BoxH\x00\x12%\n\x05plane\x18\x05 \x01(\x0b\x32\x14.brax.Collider.PlaneH\x00\x12\'\n\x06sphere\x18\x06 \x01(\x0b\x32\x15.brax.Collider.SphereH\x00\x12)\n\x07\x63\x61psule\x18\x07 \x01(\x0b\x32\x16.brax.Collider.CapsuleH\x00\x12-\n\theightMap\x18\x08 \x01(\x0b\x32\x18.brax.Collider.HeightMapH\x00\x1a&\n\x03\x42ox\x12\x1f\n\x08halfsize\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x1a\x07\n\x05Plane\x1a\x18\n\x06Sphere\x12\x0e\n\x06radius\x18\x01 \x01(\x02\x1a\x36\n\x07\x43\x61psule\x12\x0e\n\x06radius\x18\x01 \x01(\x02\x12\x0e\n\x06length\x18\x02 \x01(\x02\x12\x0b\n\x03\x65nd\x18\x03 \x01(\x05\x1a\'\n\tHeightMap\x12\x0c\n\x04size\x18\x01 \x01(\x02\x12\x0c\n\x04\x64\x61ta\x18\x02 \x03(\x02\x42\x06\n\x04typeB\x0b\n\t_friction\"\xf7\x02\n\x05Joint\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tstiffness\x18\x02 \x01(\x02\x12\x0e\n\x06parent\x18\x03 \x01(\t\x12\r\n\x05\x63hild\x18\x04 \x01(\t\x12$\n\rparent_offset\x18\x05 \x01(\x0b\x32\r.brax.Vector3\x12#\n\x0c\x63hild_offset\x18\x06 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x07 \x01(\x0b\x32\r.brax.Vector3\x12\x17\n\x0f\x61ngular_damping\x18\x08 \x01(\x02\x12&\n\x0b\x61ngle_limit\x18\t \x03(\x0b\x32\x11.brax.Joint.Range\x12\x1b\n\x0elimit_strength\x18\n \x01(\x02H\x00\x88\x01\x01\x12\x1b\n\x0espring_damping\x18\x0b \x01(\x02H\x01\x88\x01\x01\x1a!\n\x05Range\x12\x0b\n\x03min\x18\x01 \x01(\x02\x12\x0b\n\x03max\x18\x02 \x01(\x02\x42\x11\n\x0f_limit_strengthB\x11\n\x0f_spring_damping\"\xa4\x01\n\x08\x41\x63tuator\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05joint\x18\x02 \x01(\t\x12\x10\n\x08strength\x18\x03 \x01(\x02\x12\'\n\x06torque\x18\x04 \x01(\x0b\x32\x15.brax.Actuator.TorqueH\x00\x12%\n\x05\x61ngle\x18\x05 \x01(\x0b\x32\x14.brax.Actuator.AngleH\x00\x1a\x08\n\x06Torque\x1a\x07\n\x05\x41ngleB\x06\n\x04type\"\xa0\x02\n\x0c\x44\x65\x66\x61ultState\x12-\n\x06\x61ngles\x18\x01 \x03(\x0b\x32\x1d.brax.DefaultState.JointAngle\x12\"\n\x03qps\x18\x02 \x03(\x0b\x32\x15.brax.DefaultState.QP\x1a\x38\n\nJointAngle\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1c\n\x05\x61ngle\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x1a\x82\x01\n\x02QP\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x03pos\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03rot\x18\x03 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03vel\x18\x04 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03\x61ng\x18\x05 \x01(\x0b\x32\r.brax.Vector3\"\xb1\x03\n\x06\x43onfig\x12\x1a\n\x06\x62odies\x18\x01 \x03(\x0b\x32\n.brax.Body\x12\x1b\n\x06joints\x18\x02 \x03(\x0b\x32\x0b.brax.Joint\x12!\n\tactuators\x18\x03 \x03(\x0b\x32\x0e.brax.Actuator\x12\x12\n\nelasticity\x18\x04 \x01(\x02\x12\x10\n\x08\x66riction\x18\x05 \x01(\x02\x12\x1e\n\x07gravity\x18\x06 \x01(\x0b\x32\r.brax.Vector3\x12\x18\n\x10velocity_damping\x18\x07 \x01(\x02\x12\x17\n\x0f\x61ngular_damping\x18\x08 \x01(\x02\x12\x15\n\rbaumgarte_erp\x18\t \x01(\x02\x12.\n\x0f\x63ollide_include\x18\n \x03(\x0b\x32\x15.brax.Config.NamePair\x12\n\n\x02\x64t\x18\x0b \x01(\x02\x12\x10\n\x08substeps\x18\x0c \x01(\x05\x12\x1c\n\x06\x66rozen\x18\r \x01(\x0b\x32\x0c.brax.Frozen\x12$\n\x08\x64\x65\x66\x61ults\x18\x0e \x03(\x0b\x32\x12.brax.DefaultState\x1a)\n\x08NamePair\x12\r\n\x05\x66irst\x18\x01 \x01(\t\x12\x0e\n\x06second\x18\x02 \x01(\tb\x06proto3'
 )
 
 
@@ -204,8 +204,8 @@ _COLLIDER_BOX = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=586,
-  serialized_end=624,
+  serialized_start=609,
+  serialized_end=647,
 )
 
 _COLLIDER_PLANE = _descriptor.Descriptor(
@@ -228,8 +228,8 @@ _COLLIDER_PLANE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=626,
-  serialized_end=633,
+  serialized_start=649,
+  serialized_end=656,
 )
 
 _COLLIDER_SPHERE = _descriptor.Descriptor(
@@ -259,8 +259,8 @@ _COLLIDER_SPHERE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=635,
-  serialized_end=659,
+  serialized_start=658,
+  serialized_end=682,
 )
 
 _COLLIDER_CAPSULE = _descriptor.Descriptor(
@@ -304,8 +304,8 @@ _COLLIDER_CAPSULE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=661,
-  serialized_end=715,
+  serialized_start=684,
+  serialized_end=738,
 )
 
 _COLLIDER_HEIGHTMAP = _descriptor.Descriptor(
@@ -342,8 +342,8 @@ _COLLIDER_HEIGHTMAP = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=717,
-  serialized_end=756,
+  serialized_start=740,
+  serialized_end=779,
 )
 
 _COLLIDER = _descriptor.Descriptor(
@@ -369,36 +369,43 @@ _COLLIDER = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='box', full_name='brax.Collider.box', index=2,
-      number=3, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
+      name='friction', full_name='brax.Collider.friction', index=2,
+      number=3, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='plane', full_name='brax.Collider.plane', index=3,
+      name='box', full_name='brax.Collider.box', index=3,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='sphere', full_name='brax.Collider.sphere', index=4,
+      name='plane', full_name='brax.Collider.plane', index=4,
       number=5, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='capsule', full_name='brax.Collider.capsule', index=5,
+      name='sphere', full_name='brax.Collider.sphere', index=5,
       number=6, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='heightMap', full_name='brax.Collider.heightMap', index=6,
+      name='capsule', full_name='brax.Collider.capsule', index=6,
       number=7, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='heightMap', full_name='brax.Collider.heightMap', index=7,
+      number=8, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -419,9 +426,14 @@ _COLLIDER = _descriptor.Descriptor(
       index=0, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_friction', full_name='brax.Collider._friction',
+      index=1, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
   ],
   serialized_start=303,
-  serialized_end=764,
+  serialized_end=800,
 )
 
 
@@ -459,8 +471,8 @@ _JOINT_RANGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1071,
-  serialized_end=1104,
+  serialized_start=1107,
+  serialized_end=1140,
 )
 
 _JOINT = _descriptor.Descriptor(
@@ -570,8 +582,8 @@ _JOINT = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=767,
-  serialized_end=1142,
+  serialized_start=803,
+  serialized_end=1178,
 )
 
 
@@ -595,8 +607,8 @@ _ACTUATOR_TORQUE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1284,
-  serialized_end=1292,
+  serialized_start=1320,
+  serialized_end=1328,
 )
 
 _ACTUATOR_ANGLE = _descriptor.Descriptor(
@@ -619,8 +631,8 @@ _ACTUATOR_ANGLE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1294,
-  serialized_end=1301,
+  serialized_start=1330,
+  serialized_end=1337,
 )
 
 _ACTUATOR = _descriptor.Descriptor(
@@ -683,8 +695,8 @@ _ACTUATOR = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=1145,
-  serialized_end=1309,
+  serialized_start=1181,
+  serialized_end=1345,
 )
 
 
@@ -722,8 +734,8 @@ _DEFAULTSTATE_JOINTANGLE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1411,
-  serialized_end=1467,
+  serialized_start=1447,
+  serialized_end=1503,
 )
 
 _DEFAULTSTATE_QP = _descriptor.Descriptor(
@@ -781,8 +793,8 @@ _DEFAULTSTATE_QP = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1470,
-  serialized_end=1600,
+  serialized_start=1506,
+  serialized_end=1636,
 )
 
 _DEFAULTSTATE = _descriptor.Descriptor(
@@ -819,8 +831,8 @@ _DEFAULTSTATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1312,
-  serialized_end=1600,
+  serialized_start=1348,
+  serialized_end=1636,
 )
 
 
@@ -858,8 +870,8 @@ _CONFIG_NAMEPAIR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1995,
-  serialized_end=2036,
+  serialized_start=2031,
+  serialized_end=2072,
 )
 
 _CONFIG = _descriptor.Descriptor(
@@ -980,8 +992,8 @@ _CONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1603,
-  serialized_end=2036,
+  serialized_start=1639,
+  serialized_end=2072,
 )
 
 _FROZEN.fields_by_name['position'].message_type = _VECTOR3
@@ -1017,6 +1029,9 @@ _COLLIDER.fields_by_name['capsule'].containing_oneof = _COLLIDER.oneofs_by_name[
 _COLLIDER.oneofs_by_name['type'].fields.append(
   _COLLIDER.fields_by_name['heightMap'])
 _COLLIDER.fields_by_name['heightMap'].containing_oneof = _COLLIDER.oneofs_by_name['type']
+_COLLIDER.oneofs_by_name['_friction'].fields.append(
+  _COLLIDER.fields_by_name['friction'])
+_COLLIDER.fields_by_name['friction'].containing_oneof = _COLLIDER.oneofs_by_name['_friction']
 _JOINT_RANGE.containing_type = _JOINT
 _JOINT.fields_by_name['parent_offset'].message_type = _VECTOR3
 _JOINT.fields_by_name['child_offset'].message_type = _VECTOR3


### PR DESCRIPTION
* Add optional float field "friction" to colliders; If unspecified, the global friction coefficient is applied
* Re-compile protobuf file (config_pb2.py)
* Introduce Collider dataclass to pass into _collide() and _collide_pair()
* Replace references to config.friction with per-body friction (Collider.friction)

Fixes #55 

Please note:

1. I did some primitive tests within `physics_test.py` but observed that the simulation is currently unstable with friction due to lateral friction, no matter how large I set the number of substeps. Hence I ended up rolling back, in case someone else can advise. I'd appreciate any help writing tests for these changes in near future.

2. I am preserving the plane-body (and mesh-body?) collision behaviour in  `_collide()`, i.e. only the body's coefficient matters and not the plane's. However, a plane's collision coefficient is pretty important for rolling and sliding motions. I'm not a simulation expert yet, but I'd love to see how e.g. Bullet or MuJoCo implements lateral friction.