### PR TITLE
Enable per-collider friction specification

### DIFF
--- a/brax/envs/grasp.py
+++ b/brax/envs/grasp.py
@@ -706,7 +706,7 @@ actuators {
   strength: 300.0
   angle {}
 }
-friction: 0.6000000238418579
+friction: 0.77459666924
 gravity {
   z: -9.800000190734863
 }

--- a/brax/physics/base.py
+++ b/brax/physics/base.py
@@ -195,6 +195,12 @@ def validate_config(config: config_pb2.Config) -> config_pb2.Config:
         b.frozen.rotation.x, b.frozen.rotation.y, b.frozen.rotation.z
     ]):
       b.frozen.all = True
+
+    # insert material properties to colliders
+    for c in b.colliders:
+      if not c.HasField("material"):
+        c.material.friction = config.friction
+
   frozen.all = all(b.frozen.all for b in config.bodies)
 
   return config

--- a/brax/physics/config.proto
+++ b/brax/physics/config.proto
@@ -61,6 +61,12 @@ message Collider {
     float size = 1;
     repeated float data = 2;
   }
+  // High-level message for containing elasticity and friction information
+  message Material {
+    // How much surfaces in contact resist translation
+    float friction = 1;  // When unspecified, defaults to global friction coefficient
+    // TODO: add elasticity coefficient (float elasticity = 2);
+  }
   // Position relative to parent body
   Vector3 position = 1;
   // Rotation relative to parent body
@@ -73,6 +79,8 @@ message Collider {
     Capsule capsule = 6;
     HeightMap heightMap = 7;
   }
+  // Material properties (e.g. friction, elasticity) specific to the collider
+  Material material = 8;
 }
 
 // Joints connect two bodies and restrain their movement to a rotational frame.
@@ -196,6 +204,7 @@ message Config {
   repeated Actuator actuators = 3;
   // Forces to apply to bodies
   repeated Force forces = 16;
+  // TODO: encapsulate global elasticity and friction into global material
   // Bounciness of all collisions
   float elasticity = 4;
   // How much surfaces in contact resist translation

--- a/brax/physics/config_pb2.py
+++ b/brax/physics/config_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x19\x62rax/physics/config.proto\x12\x04\x62rax\"*\n\x07Vector3\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"W\n\x06\x46rozen\x12\x1f\n\x08position\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12\x0b\n\x03\x61ll\x18\x03 \x01(\x08\"\x83\x01\n\x04\x42ody\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\tcolliders\x18\x02 \x03(\x0b\x32\x0e.brax.Collider\x12\x1e\n\x07inertia\x18\x03 \x01(\x0b\x32\r.brax.Vector3\x12\x0c\n\x04mass\x18\x04 \x01(\x02\x12\x1c\n\x06\x66rozen\x18\x05 \x01(\x0b\x32\x0c.brax.Frozen\"\xcd\x03\n\x08\x43ollider\x12\x1f\n\x08position\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12!\n\x03\x62ox\x18\x03 \x01(\x0b\x32\x12.brax.Collider.BoxH\x00\x12%\n\x05plane\x18\x04 \x01(\x0b\x32\x14.brax.Collider.PlaneH\x00\x12\'\n\x06sphere\x18\x05 \x01(\x0b\x32\x15.brax.Collider.SphereH\x00\x12)\n\x07\x63\x61psule\x18\x06 \x01(\x0b\x32\x16.brax.Collider.CapsuleH\x00\x12-\n\theightMap\x18\x07 \x01(\x0b\x32\x18.brax.Collider.HeightMapH\x00\x1a&\n\x03\x42ox\x12\x1f\n\x08halfsize\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x1a\x07\n\x05Plane\x1a\x18\n\x06Sphere\x12\x0e\n\x06radius\x18\x01 \x01(\x02\x1a\x36\n\x07\x43\x61psule\x12\x0e\n\x06radius\x18\x01 \x01(\x02\x12\x0e\n\x06length\x18\x02 \x01(\x02\x12\x0b\n\x03\x65nd\x18\x03 \x01(\x05\x1a\'\n\tHeightMap\x12\x0c\n\x04size\x18\x01 \x01(\x02\x12\x0c\n\x04\x64\x61ta\x18\x02 \x03(\x02\x42\x06\n\x04type\"\xa2\x03\n\x05Joint\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tstiffness\x18\x02 \x01(\x02\x12\x0e\n\x06parent\x18\x03 \x01(\t\x12\r\n\x05\x63hild\x18\x04 \x01(\t\x12$\n\rparent_offset\x18\x05 \x01(\x0b\x32\r.brax.Vector3\x12#\n\x0c\x63hild_offset\x18\x06 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x07 \x01(\x0b\x32\r.brax.Vector3\x12\x17\n\x0f\x61ngular_damping\x18\x08 \x01(\x02\x12&\n\x0b\x61ngle_limit\x18\t \x03(\x0b\x32\x11.brax.Joint.Range\x12\x1b\n\x0elimit_strength\x18\n \x01(\x02H\x00\x88\x01\x01\x12\x1b\n\x0espring_damping\x18\x0b \x01(\x02H\x01\x88\x01\x01\x12)\n\x12reference_rotation\x18\x0c \x01(\x0b\x32\r.brax.Vector3\x1a!\n\x05Range\x12\x0b\n\x03min\x18\x01 \x01(\x02\x12\x0b\n\x03max\x18\x02 \x01(\x02\x42\x11\n\x0f_limit_strengthB\x11\n\x0f_spring_damping\"\xa4\x01\n\x08\x41\x63tuator\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05joint\x18\x02 \x01(\t\x12\x10\n\x08strength\x18\x03 \x01(\x02\x12\'\n\x06torque\x18\x04 \x01(\x0b\x32\x15.brax.Actuator.TorqueH\x00\x12%\n\x05\x61ngle\x18\x05 \x01(\x0b\x32\x14.brax.Actuator.AngleH\x00\x1a\x08\n\x06Torque\x1a\x07\n\x05\x41ngleB\x06\n\x04type\"s\n\x05\x46orce\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x62ody\x18\x02 \x01(\t\x12\x10\n\x08strength\x18\x03 \x01(\x02\x12(\n\x08thruster\x18\x04 \x01(\x0b\x32\x14.brax.Force.ThrusterH\x00\x1a\n\n\x08ThrusterB\x06\n\x04type\"\xa0\x02\n\x0c\x44\x65\x66\x61ultState\x12-\n\x06\x61ngles\x18\x01 \x03(\x0b\x32\x1d.brax.DefaultState.JointAngle\x12\"\n\x03qps\x18\x02 \x03(\x0b\x32\x15.brax.DefaultState.QP\x1a\x38\n\nJointAngle\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1c\n\x05\x61ngle\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x1a\x82\x01\n\x02QP\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x03pos\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03rot\x18\x03 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03vel\x18\x04 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03\x61ng\x18\x05 \x01(\x0b\x32\r.brax.Vector3\"\xe7\x03\n\x06\x43onfig\x12\x1a\n\x06\x62odies\x18\x01 \x03(\x0b\x32\n.brax.Body\x12\x1b\n\x06joints\x18\x02 \x03(\x0b\x32\x0b.brax.Joint\x12!\n\tactuators\x18\x03 \x03(\x0b\x32\x0e.brax.Actuator\x12\x1b\n\x06\x66orces\x18\x10 \x03(\x0b\x32\x0b.brax.Force\x12\x12\n\nelasticity\x18\x04 \x01(\x02\x12\x10\n\x08\x66riction\x18\x05 \x01(\x02\x12\x1e\n\x07gravity\x18\x06 \x01(\x0b\x32\r.brax.Vector3\x12\x18\n\x10velocity_damping\x18\x07 \x01(\x02\x12\x17\n\x0f\x61ngular_damping\x18\x08 \x01(\x02\x12\x15\n\rbaumgarte_erp\x18\t \x01(\x02\x12.\n\x0f\x63ollide_include\x18\n \x03(\x0b\x32\x15.brax.Config.NamePair\x12\n\n\x02\x64t\x18\x0b \x01(\x02\x12\x10\n\x08substeps\x18\x0c \x01(\x05\x12\x1c\n\x06\x66rozen\x18\r \x01(\x0b\x32\x0c.brax.Frozen\x12$\n\x08\x64\x65\x66\x61ults\x18\x0e \x03(\x0b\x32\x12.brax.DefaultState\x12\x17\n\x0f\x63ollider_cutoff\x18\x0f \x01(\x05\x1a)\n\x08NamePair\x12\r\n\x05\x66irst\x18\x01 \x01(\t\x12\x0e\n\x06second\x18\x02 \x01(\tb\x06proto3'
+  serialized_pb=b'\n\x19\x62rax/physics/config.proto\x12\x04\x62rax\"*\n\x07Vector3\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"W\n\x06\x46rozen\x12\x1f\n\x08position\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12\x0b\n\x03\x61ll\x18\x03 \x01(\x08\"\x83\x01\n\x04\x42ody\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\tcolliders\x18\x02 \x03(\x0b\x32\x0e.brax.Collider\x12\x1e\n\x07inertia\x18\x03 \x01(\x0b\x32\r.brax.Vector3\x12\x0c\n\x04mass\x18\x04 \x01(\x02\x12\x1c\n\x06\x66rozen\x18\x05 \x01(\x0b\x32\x0c.brax.Frozen\"\x96\x04\n\x08\x43ollider\x12\x1f\n\x08position\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12!\n\x03\x62ox\x18\x03 \x01(\x0b\x32\x12.brax.Collider.BoxH\x00\x12%\n\x05plane\x18\x04 \x01(\x0b\x32\x14.brax.Collider.PlaneH\x00\x12\'\n\x06sphere\x18\x05 \x01(\x0b\x32\x15.brax.Collider.SphereH\x00\x12)\n\x07\x63\x61psule\x18\x06 \x01(\x0b\x32\x16.brax.Collider.CapsuleH\x00\x12-\n\theightMap\x18\x07 \x01(\x0b\x32\x18.brax.Collider.HeightMapH\x00\x12)\n\x08material\x18\x08 \x01(\x0b\x32\x17.brax.Collider.Material\x1a&\n\x03\x42ox\x12\x1f\n\x08halfsize\x18\x01 \x01(\x0b\x32\r.brax.Vector3\x1a\x07\n\x05Plane\x1a\x18\n\x06Sphere\x12\x0e\n\x06radius\x18\x01 \x01(\x02\x1a\x36\n\x07\x43\x61psule\x12\x0e\n\x06radius\x18\x01 \x01(\x02\x12\x0e\n\x06length\x18\x02 \x01(\x02\x12\x0b\n\x03\x65nd\x18\x03 \x01(\x05\x1a\'\n\tHeightMap\x12\x0c\n\x04size\x18\x01 \x01(\x02\x12\x0c\n\x04\x64\x61ta\x18\x02 \x03(\x02\x1a\x1c\n\x08Material\x12\x10\n\x08\x66riction\x18\x01 \x01(\x02\x42\x06\n\x04type\"\xa2\x03\n\x05Joint\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tstiffness\x18\x02 \x01(\x02\x12\x0e\n\x06parent\x18\x03 \x01(\t\x12\r\n\x05\x63hild\x18\x04 \x01(\t\x12$\n\rparent_offset\x18\x05 \x01(\x0b\x32\r.brax.Vector3\x12#\n\x0c\x63hild_offset\x18\x06 \x01(\x0b\x32\r.brax.Vector3\x12\x1f\n\x08rotation\x18\x07 \x01(\x0b\x32\r.brax.Vector3\x12\x17\n\x0f\x61ngular_damping\x18\x08 \x01(\x02\x12&\n\x0b\x61ngle_limit\x18\t \x03(\x0b\x32\x11.brax.Joint.Range\x12\x1b\n\x0elimit_strength\x18\n \x01(\x02H\x00\x88\x01\x01\x12\x1b\n\x0espring_damping\x18\x0b \x01(\x02H\x01\x88\x01\x01\x12)\n\x12reference_rotation\x18\x0c \x01(\x0b\x32\r.brax.Vector3\x1a!\n\x05Range\x12\x0b\n\x03min\x18\x01 \x01(\x02\x12\x0b\n\x03max\x18\x02 \x01(\x02\x42\x11\n\x0f_limit_strengthB\x11\n\x0f_spring_damping\"\xa4\x01\n\x08\x41\x63tuator\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05joint\x18\x02 \x01(\t\x12\x10\n\x08strength\x18\x03 \x01(\x02\x12\'\n\x06torque\x18\x04 \x01(\x0b\x32\x15.brax.Actuator.TorqueH\x00\x12%\n\x05\x61ngle\x18\x05 \x01(\x0b\x32\x14.brax.Actuator.AngleH\x00\x1a\x08\n\x06Torque\x1a\x07\n\x05\x41ngleB\x06\n\x04type\"s\n\x05\x46orce\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x62ody\x18\x02 \x01(\t\x12\x10\n\x08strength\x18\x03 \x01(\x02\x12(\n\x08thruster\x18\x04 \x01(\x0b\x32\x14.brax.Force.ThrusterH\x00\x1a\n\n\x08ThrusterB\x06\n\x04type\"\xa0\x02\n\x0c\x44\x65\x66\x61ultState\x12-\n\x06\x61ngles\x18\x01 \x03(\x0b\x32\x1d.brax.DefaultState.JointAngle\x12\"\n\x03qps\x18\x02 \x03(\x0b\x32\x15.brax.DefaultState.QP\x1a\x38\n\nJointAngle\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1c\n\x05\x61ngle\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x1a\x82\x01\n\x02QP\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x03pos\x18\x02 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03rot\x18\x03 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03vel\x18\x04 \x01(\x0b\x32\r.brax.Vector3\x12\x1a\n\x03\x61ng\x18\x05 \x01(\x0b\x32\r.brax.Vector3\"\xe7\x03\n\x06\x43onfig\x12\x1a\n\x06\x62odies\x18\x01 \x03(\x0b\x32\n.brax.Body\x12\x1b\n\x06joints\x18\x02 \x03(\x0b\x32\x0b.brax.Joint\x12!\n\tactuators\x18\x03 \x03(\x0b\x32\x0e.brax.Actuator\x12\x1b\n\x06\x66orces\x18\x10 \x03(\x0b\x32\x0b.brax.Force\x12\x12\n\nelasticity\x18\x04 \x01(\x02\x12\x10\n\x08\x66riction\x18\x05 \x01(\x02\x12\x1e\n\x07gravity\x18\x06 \x01(\x0b\x32\r.brax.Vector3\x12\x18\n\x10velocity_damping\x18\x07 \x01(\x02\x12\x17\n\x0f\x61ngular_damping\x18\x08 \x01(\x02\x12\x15\n\rbaumgarte_erp\x18\t \x01(\x02\x12.\n\x0f\x63ollide_include\x18\n \x03(\x0b\x32\x15.brax.Config.NamePair\x12\n\n\x02\x64t\x18\x0b \x01(\x02\x12\x10\n\x08substeps\x18\x0c \x01(\x05\x12\x1c\n\x06\x66rozen\x18\r \x01(\x0b\x32\x0c.brax.Frozen\x12$\n\x08\x64\x65\x66\x61ults\x18\x0e \x03(\x0b\x32\x12.brax.DefaultState\x12\x17\n\x0f\x63ollider_cutoff\x18\x0f \x01(\x05\x1a)\n\x08NamePair\x12\r\n\x05\x66irst\x18\x01 \x01(\t\x12\x0e\n\x06second\x18\x02 \x01(\tb\x06proto3'
 )
 
 
@@ -204,8 +204,8 @@ _COLLIDER_BOX = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=586,
-  serialized_end=624,
+  serialized_start=629,
+  serialized_end=667,
 )
 
 _COLLIDER_PLANE = _descriptor.Descriptor(
@@ -228,8 +228,8 @@ _COLLIDER_PLANE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=626,
-  serialized_end=633,
+  serialized_start=669,
+  serialized_end=676,
 )
 
 _COLLIDER_SPHERE = _descriptor.Descriptor(
@@ -259,8 +259,8 @@ _COLLIDER_SPHERE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=635,
-  serialized_end=659,
+  serialized_start=678,
+  serialized_end=702,
 )
 
 _COLLIDER_CAPSULE = _descriptor.Descriptor(
@@ -304,8 +304,8 @@ _COLLIDER_CAPSULE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=661,
-  serialized_end=715,
+  serialized_start=704,
+  serialized_end=758,
 )
 
 _COLLIDER_HEIGHTMAP = _descriptor.Descriptor(
@@ -342,8 +342,39 @@ _COLLIDER_HEIGHTMAP = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=717,
-  serialized_end=756,
+  serialized_start=760,
+  serialized_end=799,
+)
+
+_COLLIDER_MATERIAL = _descriptor.Descriptor(
+  name='Material',
+  full_name='brax.Collider.Material',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='friction', full_name='brax.Collider.Material.friction', index=0,
+      number=1, type=2, cpp_type=6, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=801,
+  serialized_end=829,
 )
 
 _COLLIDER = _descriptor.Descriptor(
@@ -403,10 +434,17 @@ _COLLIDER = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='material', full_name='brax.Collider.material', index=7,
+      number=8, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
-  nested_types=[_COLLIDER_BOX, _COLLIDER_PLANE, _COLLIDER_SPHERE, _COLLIDER_CAPSULE, _COLLIDER_HEIGHTMAP, ],
+  nested_types=[_COLLIDER_BOX, _COLLIDER_PLANE, _COLLIDER_SPHERE, _COLLIDER_CAPSULE, _COLLIDER_HEIGHTMAP, _COLLIDER_MATERIAL, ],
   enum_types=[
   ],
   serialized_options=None,
@@ -421,7 +459,7 @@ _COLLIDER = _descriptor.Descriptor(
     fields=[]),
   ],
   serialized_start=303,
-  serialized_end=764,
+  serialized_end=837,
 )
 
 
@@ -459,8 +497,8 @@ _JOINT_RANGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1114,
-  serialized_end=1147,
+  serialized_start=1187,
+  serialized_end=1220,
 )
 
 _JOINT = _descriptor.Descriptor(
@@ -577,8 +615,8 @@ _JOINT = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=767,
-  serialized_end=1185,
+  serialized_start=840,
+  serialized_end=1258,
 )
 
 
@@ -602,8 +640,8 @@ _ACTUATOR_TORQUE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1327,
-  serialized_end=1335,
+  serialized_start=1400,
+  serialized_end=1408,
 )
 
 _ACTUATOR_ANGLE = _descriptor.Descriptor(
@@ -626,8 +664,8 @@ _ACTUATOR_ANGLE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1337,
-  serialized_end=1344,
+  serialized_start=1410,
+  serialized_end=1417,
 )
 
 _ACTUATOR = _descriptor.Descriptor(
@@ -690,8 +728,8 @@ _ACTUATOR = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=1188,
-  serialized_end=1352,
+  serialized_start=1261,
+  serialized_end=1425,
 )
 
 
@@ -715,8 +753,8 @@ _FORCE_THRUSTER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1451,
-  serialized_end=1461,
+  serialized_start=1524,
+  serialized_end=1534,
 )
 
 _FORCE = _descriptor.Descriptor(
@@ -772,8 +810,8 @@ _FORCE = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=1354,
-  serialized_end=1469,
+  serialized_start=1427,
+  serialized_end=1542,
 )
 
 
@@ -811,8 +849,8 @@ _DEFAULTSTATE_JOINTANGLE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1571,
-  serialized_end=1627,
+  serialized_start=1644,
+  serialized_end=1700,
 )
 
 _DEFAULTSTATE_QP = _descriptor.Descriptor(
@@ -870,8 +908,8 @@ _DEFAULTSTATE_QP = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1630,
-  serialized_end=1760,
+  serialized_start=1703,
+  serialized_end=1833,
 )
 
 _DEFAULTSTATE = _descriptor.Descriptor(
@@ -908,8 +946,8 @@ _DEFAULTSTATE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1472,
-  serialized_end=1760,
+  serialized_start=1545,
+  serialized_end=1833,
 )
 
 
@@ -947,8 +985,8 @@ _CONFIG_NAMEPAIR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2209,
-  serialized_end=2250,
+  serialized_start=2282,
+  serialized_end=2323,
 )
 
 _CONFIG = _descriptor.Descriptor(
@@ -1083,8 +1121,8 @@ _CONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1763,
-  serialized_end=2250,
+  serialized_start=1836,
+  serialized_end=2323,
 )
 
 _FROZEN.fields_by_name['position'].message_type = _VECTOR3
@@ -1098,6 +1136,7 @@ _COLLIDER_PLANE.containing_type = _COLLIDER
 _COLLIDER_SPHERE.containing_type = _COLLIDER
 _COLLIDER_CAPSULE.containing_type = _COLLIDER
 _COLLIDER_HEIGHTMAP.containing_type = _COLLIDER
+_COLLIDER_MATERIAL.containing_type = _COLLIDER
 _COLLIDER.fields_by_name['position'].message_type = _VECTOR3
 _COLLIDER.fields_by_name['rotation'].message_type = _VECTOR3
 _COLLIDER.fields_by_name['box'].message_type = _COLLIDER_BOX
@@ -1105,6 +1144,7 @@ _COLLIDER.fields_by_name['plane'].message_type = _COLLIDER_PLANE
 _COLLIDER.fields_by_name['sphere'].message_type = _COLLIDER_SPHERE
 _COLLIDER.fields_by_name['capsule'].message_type = _COLLIDER_CAPSULE
 _COLLIDER.fields_by_name['heightMap'].message_type = _COLLIDER_HEIGHTMAP
+_COLLIDER.fields_by_name['material'].message_type = _COLLIDER_MATERIAL
 _COLLIDER.oneofs_by_name['type'].fields.append(
   _COLLIDER.fields_by_name['box'])
 _COLLIDER.fields_by_name['box'].containing_oneof = _COLLIDER.oneofs_by_name['type']
@@ -1233,6 +1273,13 @@ Collider = _reflection.GeneratedProtocolMessageType('Collider', (_message.Messag
     # @@protoc_insertion_point(class_scope:brax.Collider.HeightMap)
     })
   ,
+
+  'Material' : _reflection.GeneratedProtocolMessageType('Material', (_message.Message,), {
+    'DESCRIPTOR' : _COLLIDER_MATERIAL,
+    '__module__' : 'brax.physics.config_pb2'
+    # @@protoc_insertion_point(class_scope:brax.Collider.Material)
+    })
+  ,
   'DESCRIPTOR' : _COLLIDER,
   '__module__' : 'brax.physics.config_pb2'
   # @@protoc_insertion_point(class_scope:brax.Collider)
@@ -1243,6 +1290,7 @@ _sym_db.RegisterMessage(Collider.Plane)
 _sym_db.RegisterMessage(Collider.Sphere)
 _sym_db.RegisterMessage(Collider.Capsule)
 _sym_db.RegisterMessage(Collider.HeightMap)
+_sym_db.RegisterMessage(Collider.Material)
 
 Joint = _reflection.GeneratedProtocolMessageType('Joint', (_message.Message,), {
 


### PR DESCRIPTION
* Add optional float field "friction" to colliders; If unspecified, the global friction coefficient is applied
* Re-compile protobuf file (config_pb2.py)
* Introduce Collider dataclass to pass into _collide() and _collide_pair()
* Replace references to config.friction with per-body friction (Collider.friction)

Fixes #55

Please note:

1. I did some primitive tests within physics_test.py but observed that the simulation is currently unstable with friction due to lateral friction, no matter how large I set the number of substeps. Hence I ended up rolling back, in case someone else can advise. I'd appreciate any help writing tests for these changes in near future.

2. I am preserving the plane-body (and mesh-body?) collision behaviour in _collide(), i.e. only the body's coefficient matters and not the plane's. However, a plane's collision coefficient is pretty important for rolling and sliding motions. I'm not a simulation expert yet, but I'd love to see how e.g. Bullet or MuJoCo implements lateral friction.
