### PR TITLE
fix integrator, causing incorrect rotational update

### DIFF
--- a/brax/physics/integrators.py
+++ b/brax/physics/integrators.py
@@ -40,10 +40,8 @@ def kinetic(_, qp: QP, dt: float, active_pos: jnp.ndarray,
   def op(qp: QP, active_pos: jnp.ndarray,
          active_rot: jnp.ndarray) -> QP:
     pos = qp.pos + qp.vel * dt * active_pos
-    rot_at_ang_quat = math.ang_to_quat(qp.ang * active_rot)
-    rot = jnp.matmul(
-        jnp.matmul(jnp.eye(4) + .5 * dt * rot_at_ang_quat, qp.rot),
-        jnp.eye(4) - .5 * dt * rot_at_ang_quat)
+    rot_at_ang_quat = math.ang_to_quat(qp.ang * active_rot)*0.5*dt
+    rot = qp.rot+math.qmult(rot_at_ang_quat,qp.rot)
     rot = rot / jnp.linalg.norm(rot)
     return QP(pos=pos, rot=rot, vel=qp.vel, ang=qp.ang)
 

--- a/brax/physics/math.py
+++ b/brax/physics/math.py
@@ -85,9 +85,7 @@ def ang_to_quat(ang: jnp.ndarray):
   Returns:
     A rotation quaternion.
   """
-  return jnp.array([[0., -ang[0], -ang[1], -ang[2]],
-                    [ang[0], 0, -ang[2], ang[1]], [ang[1], ang[2], 0., -ang[0]],
-                    [ang[2], -ang[1], ang[0], 0.]])
+  return jnp.array([0., ang[0], ang[1], ang[2]])
 
 
 def quat_to_axis_angle(q: jnp.ndarray):


### PR DESCRIPTION
In a nutshell, the kinetic integrator rotates twice as fast as it should do.
Small check: set time step to 0.01, run 314 steps, the object should rotate half a round (with this patch), but currently it rotates a full round. Once simple fix is replacing the 0.5 factor by 0.25 in line 45 and line 46 in integrators.py. This patch is more efficient though.
In Bullet we use an exponential map with higher accuracy, that can deal with very small angular velocities, read more about it here: https://www.cs.cmu.edu/~spiff/moedit99/expmap.pdf or code here:
https://github.com/bulletphysics/bullet3/blob/master/src/LinearMath/btTransformUtil.h#L32

See attached reproduction case (needs pip3 install meshcat)
[ballplane.zip](https://github.com/google/brax/files/7172910/ballplane.zip)
