### PR TITLE
HTML Viewer: respect size of enclosing div

### DIFF
--- a/brax/io/html.py
+++ b/brax/io/html.py
@@ -75,19 +75,6 @@ _HTML = """
       import {Viewer} from 'https://cdn.jsdelivr.net/gh/google/brax@v0.0.6/js/viewer.js';
       const domElement = document.getElementById('brax-viewer');
       var viewer = new Viewer(domElement, system);
-
-      function resizeCanvasToDisplaySize() {
-
-        // look up the size the canvas is being displayed
-        const width = domElement.clientWidth;
-        const height = domElement.clientHeight;
-
-        // you must pass false here or three.js sadly fights the browser
-        viewer.setSize(width, height, false);
-      }
-
-      const resizeObserver = new ResizeObserver(resizeCanvasToDisplaySize);
-      resizeObserver.observe(domElement, {box: 'content-box'});
     </script>
   </body>
 </html>

--- a/js/viewer.js
+++ b/js/viewer.js
@@ -160,6 +160,9 @@ class Viewer {
     window.addEventListener('resize', (evt) => this.setSize(), false);
     requestAnimationFrame(() => this.setSize());
 
+    const resizeObserver = new ResizeObserver(() => this.resizeCanvasToDisplaySize());
+    resizeObserver.observe(this.domElement, {box: 'content-box'});
+
     /* start animation */
     this.animate();
   }
@@ -184,6 +187,13 @@ class Viewer {
     this.camera.updateProjectionMatrix();
     this.renderer.setSize(w, h);
     this.setDirty();
+  }
+
+  resizeCanvasToDisplaySize() {
+    //look up canvas size
+    const width = this.domElement.clientWidth;
+    const height = this.domElement.clientHeight;
+    this.setSize(width, height);
   }
 
   render() {


### PR DESCRIPTION
Add callback to the HTML template to respect the size of the division
properly and also allow overrideing that when calling render.

Code based on https://stackoverflow.com/a/45046955