### PR TITLE
Integrate with Gym's `RecordVideo` wrapper.

### DIFF
--- a/brax/envs/wrappers.py
+++ b/brax/envs/wrappers.py
@@ -103,16 +103,16 @@ class GymWrapper(gym.Env):
   # Flag that prevents `gym.register` from misinterpreting the `_step` and
   # `_reset` as signs of a deprecated gym Env API.
   _gym_disable_underscore_compat: ClassVar[bool] = True
-  metadata = {
-    'render.modes': ['human', 'rgb_array'],
-    'video.frames_per_second' : 24
-  }
 
   def __init__(self,
                env: brax_env.Env,
                seed: int = 0,
                backend: Optional[str] = None):
     self._env = env
+    self.metadata = {
+      'render.modes': ['human', 'rgb_array'],
+      'video.frames_per_second' : 1 / self._env.sys.config.dt
+    }
     self.seed(seed)
     self.backend = backend
     self._state = None
@@ -163,16 +163,16 @@ class VectorGymWrapper(gym.vector.VectorEnv):
   # Flag that prevents `gym.register` from misinterpreting the `_step` and
   # `_reset` as signs of a deprecated gym Env API.
   _gym_disable_underscore_compat: ClassVar[bool] = True
-  metadata = {
-    'render.modes': ['human', 'rgb_array'],
-    'video.frames_per_second' : 24
-  }
 
   def __init__(self,
                env: brax_env.Env,
                seed: int = 0,
                backend: Optional[str] = None):
     self._env = env
+    self.metadata = {
+      'render.modes': ['human', 'rgb_array'],
+      'video.frames_per_second' : 1 / self._env.sys.config.dt
+    }
     if not hasattr(self._env, 'batch_size'):
       raise ValueError('underlying env must be batched')
 


### PR DESCRIPTION
This PR adds the meta-data tag that Gym's `RecordVideo` is looking for.

```
  metadata = {
    'render.modes': ['human', 'rgb_array'],
    'video.frames_per_second' : 24
  }
```

Additionally, in the case of a vector environment, the render function would only render the first sub environment for speed reasons.

You can run the following to give it a try:


```python
import gym
import torch

from brax.envs.to_torch import JaxToTorchWrapper
from brax.envs import create_gym_env

dummy_value = torch.ones(1, device="cpu")
envs = create_gym_env("halfcheetah", batch_size=2)
envs.is_vector_env = True
envs = JaxToTorchWrapper(envs, device="cpu")
envs = gym.wrappers.RecordVideo(envs, f"videos/halfcheetah", video_length=50)

obs = envs.reset()
for _ in range(100):
    obs, reward, done, info = envs.step(envs.action_space.sample())
    if done[0]:
        break
```