### PR TITLE
Count forces in the action size

### DIFF
--- a/brax/envs/env.py
+++ b/brax/envs/env.py
@@ -61,7 +61,7 @@ class Env(abc.ABC):
   @property
   def action_size(self) -> int:
     """The size of the action vector expected by step."""
-    return self.sys.num_joint_dof
+    return self.sys.num_joint_dof + self.sys.num_forces_dof
 
   @property
   def unwrapped(self) -> 'Env':

--- a/brax/physics/system.py
+++ b/brax/physics/system.py
@@ -36,7 +36,7 @@ class System:
   """A brax system."""
 
   __pytree_ignore__ = ('config', 'num_bodies', 'num_joints', 'num_joint_dof',
-                       'num_actuators')
+                       'num_actuators', 'num_forces_dof')
 
   def __init__(self, config: config_pb2.Config):
     self.config = validate_config(config)

--- a/brax/physics/system.py
+++ b/brax/physics/system.py
@@ -50,6 +50,7 @@ class System:
     self.num_joint_dof = sum(len(j.angle_limit) for j in config.joints)
     self.actuators = actuators.get(self.config, self.joints)
     self.forces = forces.get(self.config, self.body)
+    self.num_forces_dof = sum(f.act_index.shape[-1] for f in self.forces)
 
   def default_angle(self, default_index: int = 0) -> jp.ndarray:
     """Returns the default joint angles for the system."""


### PR DESCRIPTION
6fd26222e2d00de0931c708bafbbf1adf535a83a added forces, which are a lovely addition. However, they
enumerated in the action size so the policy doesn't see them. This fixes that. Partially address #61 