### PR TITLE
Walker refactor

### DIFF
--- a/brax/envs/walker2d.py
+++ b/brax/envs/walker2d.py
@@ -39,7 +39,7 @@ class Walker2d(brax_env.Env):
                exclude_current_positions_from_observation: bool = True,
                system_config: Optional[str] = None,
                **kwargs):
-    """Creates a Hopper environment.
+    """Creates a Walker environment.
 
     Args:
       forward_reward_weight: Weight for the forward reward, i.e. velocity in


### PR DESCRIPTION
Closes #92. 

I verified that the "new" walker performs the same as before the refactor. I also have a set of parameters that work consistently for walker+ppo, since I saw them missing in the demo colab (I was not able to find good parameters for hopper).

Using:
```python
 'walker2d': functools.partial(
      ppo.train, num_timesteps = 100_000_000, log_frequency = 10,
      reward_scaling = 1, episode_length = 1000, normalize_observations = True,
      action_repeat = 1, unroll_length = 20, num_minibatches = 512,
      num_update_epochs = 20, discounting = 0.99, learning_rate = 5e-5,
      entropy_cost = 0.0005, num_envs = 2048, batch_size = 32
  ),
```

I get the attached reward curve / gif. I can also include changes to the training notebook in this PR, with the minor changes needed to include the walker. Not sure what if any policy there is for notebooks in PRs since they can be painful to VC, and also not sure how to update the colab version. 

![brax_walker_reward](https://user-images.githubusercontent.com/9152639/139353306-146c8e30-3ee6-4eb4-a8f7-846b64160dff.png)
![brax_walker2](https://user-images.githubusercontent.com/9152639/139353311-74c785dc-34a0-4bf3-9d3c-99a08f761b14.gif)


