### PR TITLE
Changing humanoid termination z-threshold

### DIFF
--- a/brax/envs/humanoid.py
+++ b/brax/envs/humanoid.py
@@ -64,7 +64,7 @@ class Humanoid(env.Env):
     alive_bonus = jp.float32(5)
     reward = lin_vel_cost - quad_ctrl_cost - quad_impact_cost + alive_bonus
 
-    done = jp.where(qp.pos[0, 2] < 0.7, jp.float32(1), jp.float32(0))
+    done = jp.where(qp.pos[0, 2] < 0.72, jp.float32(1), jp.float32(0))
     done = jp.where(qp.pos[0, 2] > 2.1, jp.float32(1), done)
     state.metrics.update(
         reward_linvel=lin_vel_cost,


### PR DESCRIPTION
Hi,

I've changed the z-threshold for termination to prevent the agent from moving on knees.
The change does not affect the released notebooks (e.g., "Brax Training").