### PR TITLE
Fix: Use clientHeight as default height parameter in SetSize()

### DIFF
--- a/js/viewer.js
+++ b/js/viewer.js
@@ -185,7 +185,7 @@ class Viewer {
       w = this.domElement.offsetWidth;
     }
     if (h === undefined) {
-      h = window.innerHeight;
+      h = this.domElement.clientHeight;
     }
     if (this.camera.type == 'OrthographicCamera') {
       this.camera.right =


### PR DESCRIPTION
This is a PR for #142 

Viewer ignored specified height and became as big as possible, since the `<canvas>` height was set to `window.innerHeight` at some events.

By this PR, the `<canvas>` height will be set to `clientHeight` of
parent `<div#brax-viewer>`.

