### PR TITLE
Remove "memory leak" in PyTorch training example

### DIFF
--- a/notebooks/training_torch.ipynb
+++ b/notebooks/training_torch.ipynb
@@ -415,7 +415,7 @@
         "          optimizer.zero_grad()\n",
         "          loss.backward()\n",
         "          optimizer.step()\n",
-        "          total_loss += loss\n",
+        "          total_loss += loss.detach()\n",
         "\n",
         "    duration = time.time() - t\n",
         "    total_steps += num_epochs * num_steps\n",


### PR DESCRIPTION
Accumulating losses with a grad_fn is a memory leak, as far as I know:

(from https://pytorch.org/docs/stable/notes/faq.html#my-model-reports-cuda-runtime-error-2-out-of-memory):

> Don’t accumulate history across your training loop. By default, computations involving variables that require gradients will keep history. This means that you should avoid using such variables in computations which will live beyond your training loops, e.g., when tracking statistics. Instead, you should detach the variable or access its underlying data.

> Sometimes, it can be non-obvious when differentiable variables can occur. Consider the following training loop (abridged from source):
```python
total_loss = 0
for i in range(10000):
    optimizer.zero_grad()
    output = model(input)
    loss = criterion(output)
    loss.backward()
    optimizer.step()
    total_loss += loss
```
> Here, `total_loss` is accumulating history across your training loop, since loss is a differentiable variable with autograd history. You can fix this by writing `total_loss += float(loss)` instead.
