### PR TITLE
Add Acrobot Environment, Remove Redudant Inverted Double Pendulum Observations

### DIFF
--- a/brax/envs/__init__.py
+++ b/brax/envs/__init__.py
@@ -38,6 +38,8 @@ from brax.envs import wrappers
 from brax.envs.env import Env, State, Wrapper
 import gym
 
+from brax.envs import acrobot
+
 
 _envs = {
     'ant': ant.Ant,
@@ -54,6 +56,7 @@ _envs = {
     'reacherangle': reacherangle.ReacherAngle,
     'swimmer': swimmer.Swimmer,
     'ur5e': ur5e.Ur5e,
+    'acrobot': acrobot.Acrobot,
     'walker2d': walker2d.Walker2d,
 }
 

--- a/brax/envs/acrobot.py
+++ b/brax/envs/acrobot.py
@@ -60,14 +60,15 @@ class Acrobot(env.Env):
   def step(self, state: env.State, action: jp.ndarray) -> env.State:
     """Run one timestep of the environment's dynamics."""
     qp, info = self.sys.step(state.qp, action)
+    (joint_angle,), (joint_vel,) = self.sys.joints[0].angle_vel(qp)
     obs = self._get_obs(qp, info, joint_angle, joint_vel)
 
     alive_bonus = 10.0
-    dist_penalty = obs[0]**2 + obs[1]**2
-    vel_penalty = 1e-3*(obs[2]**2 + obs[3]**2)
+    dist_penalty = joint_angele[0]**2 + joint_angle[1]**2
+    vel_penalty = 1e-3*(joint_bel[0]**2 + joint_vel[1]**2)
     r =  alive_bonus - dist_penalty - vel_penalty
-
     done = jp.float32(0);
+    
     state.metrics.update(
         dist_penalty=dist_penalty,
         vel_penalty=vel_penalty,
@@ -82,8 +83,6 @@ class Acrobot(env.Env):
   def _get_obs(self, qp: brax.QP, info: brax.Info, joint_angle: jp.ndarray,
                joint_vel: jp.ndarray) -> jp.ndarray:
     """Observe acrobot body position and velocities."""
-
-    (joint_angle,), (joint_vel,) = self.sys.joints[0].angle_vel(qp)
  
     return jp.concatenate((joint_angle, joint_vel))
 

--- a/brax/envs/acrobot.py
+++ b/brax/envs/acrobot.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The Brax Authors.
+# Copyright 2021 The Brax Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,26 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""An inverted pendulum environment."""
+"""An acrobot environment."""
 
 import brax
 from brax import jumpy as jp
 from brax.envs import env
+import jax
 
 
-class InvertedDoublePendulum(env.Env):
-  """Trains an inverted pendulum to remain stationary.
+class Acrobot(env.Env):
+  """Trains an acrobot to swingup and balance
   Observations:
-  0. Cart X position
-  1. Sin(Theta 0)
-  2. Sin(Theta 1)
-  3. Cos(Theta 0)
-  4. Cos(Theta 1)
-  5. Cart X Velocity
-  6. dTheta 0
-  7. dTheta 1
-  
+  0. Theta 0
+  1. Theta 1
+  2. dTheta 0
+  3. dTheta 1
 
+  Actions:
+  0. Torque at the elbow joint
+  
 
   """
 
@@ -45,6 +44,7 @@ class InvertedDoublePendulum(env.Env):
         rng1, (self.sys.num_joint_dof,), -.01, .01)
     qvel = jp.random_uniform(rng2, (self.sys.num_joint_dof,), -.01, .01)
     qp = self.sys.default_qp(joint_angle=qpos, joint_velocity=qvel)
+    #    qp = self.sys.default_qp()
     info = self.sys.info(qp)
     (joint_angle,), (joint_vel,) = self.sys.joints[0].angle_vel(qp)
     obs = self._get_obs(qp, info, joint_angle, joint_vel)
@@ -59,22 +59,18 @@ class InvertedDoublePendulum(env.Env):
 
   def step(self, state: env.State, action: jp.ndarray) -> env.State:
     """Run one timestep of the environment's dynamics."""
-    alive_bonus = 10.0
     qp, info = self.sys.step(state.qp, action)
-    (joint_angle,), (joint_vel,) = self.sys.joints[0].angle_vel(qp)
     obs = self._get_obs(qp, info, joint_angle, joint_vel)
-    tip_pos = jp.take(state.qp, 2).to_world(jp.array([0, 0, .3]))
-    (x, _, y), _ = tip_pos
-    dist_penalty = 0.01 * x**2 + (y - 2)**2
-    v1, v2 = joint_vel
-    vel_penalty = 1e-3 * v1**2 + 5e-3 * v2**2
+
     alive_bonus = 10.0
-    r = alive_bonus - dist_penalty - vel_penalty
-    done = jp.where(y <= 1, jp.float32(1), jp.float32(0))
+    dist_penalty = obs[0]**2 + obs[1]**2
+    vel_penalty = 1e-3*(obs[2]**2 + obs[3]**2)
+    r =  alive_bonus - dist_penalty - vel_penalty
+
+    done = jp.float32(0);
     state.metrics.update(
         dist_penalty=dist_penalty,
         vel_penalty=vel_penalty,
-        alive_bonus=alive_bonus,
         r_tot=r)
 
     return state.replace(qp=qp, obs=obs, reward=r, done=done)
@@ -85,20 +81,11 @@ class InvertedDoublePendulum(env.Env):
 
   def _get_obs(self, qp: brax.QP, info: brax.Info, joint_angle: jp.ndarray,
                joint_vel: jp.ndarray) -> jp.ndarray:
-    """Observe cartpole body position and velocities."""
+    """Observe acrobot body position and velocities."""
 
-
-    position_obs = [
-      jp.array([qp.pos[0, 0]]),  # cart x pos
-      jp.sin(joint_angle),
-      jp.cos(joint_angle)
-    ]
-    
-    
-    qvel = [jp.array([qp.vel[0,0]]), # cart x vel
-            joint_vel]
-
-    return jp.concatenate(position_obs + qvel)
+    (joint_angle,), (joint_vel,) = self.sys.joints[0].angle_vel(qp)
+ 
+    return jp.concatenate((joint_angle, joint_vel))
 
 
 _SYSTEM_CONFIG = """
@@ -114,7 +101,7 @@ bodies {
       length: 0.4
     }
   }
-  frozen { position { x:0 y:1 z:1 } rotation { x:1 y:1 z:1 } }
+  frozen { position { x:1 y:1 z:1 } rotation { x:1 y:1 z:1 } }
   mass: 10.471975
 }
 bodies {
@@ -122,18 +109,18 @@ bodies {
   colliders {
     capsule {
       radius: 0.049
-      length: 0.69800085
+      length: 1.0 
     }
   }
   frozen { position { x: 0 y: 1 z: 0 } rotation { x: 1 y: 0 z: 1 } }
-  mass: 5.0185914
+  mass: 2.5
 }
 joints {
   name: "hinge"
   stiffness: 30000.0
   parent: "cart"
   child: "pole"
-  child_offset { z: -.3 }
+  child_offset { z: -.45 }
   rotation {
     z: 90.0
   }
@@ -146,19 +133,19 @@ bodies {
   colliders {
     capsule {
       radius: 0.049
-      length: 0.69800085
+      length:  1.00 
     }
   }
   frozen { position { x: 0 y: 1 z: 0 } rotation { x: 1 y: 0 z: 1 } }
-  mass: 5.0185914
+  mass: 2.5
 }
 joints {
   name: "hinge2"
   stiffness: 30000.0
   parent: "pole"
   child: "pole2"
-  parent_offset { z: .3 }
-  child_offset { z: -.3 }
+  parent_offset { z: .45 }
+  child_offset { z: -.45 }
   rotation {
     z: 90.0
   }
@@ -166,16 +153,27 @@ joints {
   spring_damping: 500.0
   angle_limit { min: 0.0 max: 0.0 }
 }
-forces {
-  name: "cart_thruster"
-  body: "cart"
-  strength: 500.0
-  thruster {}
+
+actuators{
+  name: "hinge2"
+  joint: "hinge2"
+  strength: 25.0
+  torque{
+  }
 }
+
+defaults {
+    angles { 
+        name: "hinge" 
+        angle{ x: 180.0 y: 0.0 z: 0.0} 
+    }
+}
+
+
 collide_include {}
 gravity {
   z: -9.81
 }
-dt: 0.05
-substeps: 12
+dt: 0.01
+substeps: 4
 """

--- a/brax/envs/acrobot.py
+++ b/brax/envs/acrobot.py
@@ -64,8 +64,8 @@ class Acrobot(env.Env):
     obs = self._get_obs(qp, info, joint_angle, joint_vel)
 
     alive_bonus = 10.0
-    dist_penalty = joint_angele[0]**2 + joint_angle[1]**2
-    vel_penalty = 1e-3*(joint_bel[0]**2 + joint_vel[1]**2)
+    dist_penalty = joint_angle[0]**2 + joint_angle[1]**2
+    vel_penalty = 1e-3*(joint_vel[0]**2 + joint_vel[1]**2)
     r =  alive_bonus - dist_penalty - vel_penalty
     done = jp.float32(0);
     

--- a/brax/envs/acrobot.py
+++ b/brax/envs/acrobot.py
@@ -125,7 +125,7 @@ joints {
   }
   limit_strength: 0.0
   spring_damping: 500.0
-  angle_limit { min: 0.0 max: 0.0 }
+  angle_limit { min: -360.0 max: 360.0 }
 }
 bodies {
   name: "pole2"
@@ -150,7 +150,7 @@ joints {
   }
   limit_strength: 0.0
   spring_damping: 500.0
-  angle_limit { min: 0.0 max: 0.0 }
+  angle_limit { min: -360.0 max: 360.0 }
 }
 
 actuators{

--- a/brax/envs/inverted_double_pendulum.py
+++ b/brax/envs/inverted_double_pendulum.py
@@ -30,9 +30,6 @@ class InvertedDoublePendulum(env.Env):
   5. Cart X Velocity
   6. dTheta 0
   7. dTheta 1
-  
-
-
   """
 
   def __init__(self, **kwargs):
@@ -87,14 +84,12 @@ class InvertedDoublePendulum(env.Env):
                joint_vel: jp.ndarray) -> jp.ndarray:
     """Observe cartpole body position and velocities."""
 
-
     position_obs = [
       jp.array([qp.pos[0, 0]]),  # cart x pos
       jp.sin(joint_angle),
       jp.cos(joint_angle)
     ]
-    
-    
+        
     qvel = [jp.array([qp.vel[0,0]]), # cart x vel
             joint_vel]
 


### PR DESCRIPTION
Hello,

I've been experimenting with some swing-up pendulum environments, I thought Brax might find some of them useful / interesting.

I am proposing adding an Acrobot environment to Brax. The one I am submitting here is a bit different and more difficult than the one in I.E. gym, since the action state in continuous, and to "solve" the environment an agent must both swing up and balance the system. I like this environment because it is deceptively difficult for most model free RL  with it (see for example [this paper](https://arxiv.org/pdf/2012.11663.pdf) I wrote a couple of years ago).

I've got my own twist on APG that works well for this acrobot, but haven't yet been able to get good performance on it from any of the brax algorithms (including APG). I would be very interested to hear if anyone gets the brax RL working well with the environment!

In this PR I also remove some redundant / useless observations from the double inverted pendulum. 

Let me know what you all think!

Edit: Also, [here is](https://colab.research.google.com/drive/1cZcaQtRjfM91Iot1cBZhITLti5FmQ0mW?usp=sharing) a basic smoke test training set up in collab.