### PR TITLE
Add an environment variable to force jumpy to use jnp

### DIFF
--- a/brax/jumpy.py
+++ b/brax/jumpy.py
@@ -17,7 +17,6 @@
 
 from typing import Any, Callable, List, Optional, Sequence, Tuple, TypeVar, Union
 import builtins
-import os
 
 import jax
 from jax import core
@@ -32,11 +31,10 @@ inf = onp.inf
 float32 = onp.float32
 int32 = onp.int32
 
-FORCE_JNP = os.getenv("JUMPY_FORCE_JNP", 'False').lower() in ('true', '1', 't')
 
 def _in_jit() -> bool:
-  """Returns true if currently inside a jax.jit call."""
-  if FORCE_JNP:
+  """Returns true if currently inside a jax.jit call or jit is disabled."""
+  if jax.config.jax_disable_jit:
     return True
   return core.cur_sublevel().level > 0
 

--- a/brax/jumpy.py
+++ b/brax/jumpy.py
@@ -24,7 +24,6 @@ from jax import core
 from jax import custom_jvp
 from jax import numpy as jnp
 import numpy as onp
-import tree
 
 ndarray = Union[onp.ndarray, jnp.ndarray]  # pylint:disable=invalid-name
 tree_map = jax.tree_map  # works great with jax or numpy as-is
@@ -46,7 +45,7 @@ def _which_np(*args):
   checker = lambda a: (
     isinstance(a, (jnp.ndarray, jax.interpreters.batching.BatchTracer))
     and not isinstance(a, onp.ndarray))
-  if builtins.any(tree.flatten(tree.map_structure(checker, args))):
+  if builtins.any(jax.tree_flatten(tree_map(checker, args))[0]):
     return jnp
   return onp
 

--- a/brax/jumpy.py
+++ b/brax/jumpy.py
@@ -155,8 +155,8 @@ def norm(x: ndarray,
 
 def index_update(x: ndarray, idx: ndarray, y: ndarray) -> ndarray:
   """Pure equivalent of x[idx] = y."""
-  if _which_np(x) is jnp:
-    return x.at[idx].set(y)
+  if _which_np(x, idx, y) is jnp:
+    return jnp.array(x).at[idx].set(jnp.array(y))
   x = onp.copy(x)
   x[idx] = y
   return x

--- a/brax/jumpy.py
+++ b/brax/jumpy.py
@@ -17,6 +17,7 @@
 
 from typing import Any, Callable, List, Optional, Sequence, Tuple, TypeVar, Union
 import builtins
+import os
 
 import jax
 from jax import core
@@ -32,9 +33,12 @@ inf = onp.inf
 float32 = onp.float32
 int32 = onp.int32
 
+FORCE_JNP = os.getenv("JUMPY_FORCE_JNP", 'False').lower() in ('true', '1', 't')
 
 def _in_jit() -> bool:
   """Returns true if currently inside a jax.jit call."""
+  if FORCE_JNP:
+    return True
   return core.cur_sublevel().level > 0
 
 


### PR DESCRIPTION
Helps with #198. These changes enable forcing jumpy to use jnp via an environment variable. This is needed when jumpy is used with jax tracing but with jit explicitly disabled.

In order to make the flag work, the `jp._which_np` has to be changed so that it checks for nested inputs. It's not clear to me what the purpose of the original `and not isinstance(a, onp.ndarray)` condition is.

Changing the jax branch behavior of `jp.index_update` was required to make this code work with `brax.training.ppo`.

There are quite a few distinct cases where jumpy needs to pick between jnp and onp. I checked that this runs with `brax.training.ppo` with jit enabled or disabled but there could be other cases that running that code didn't hit.