### PR TITLE
PPO train code refactor for checkpointing and curriculum compatibility

### DIFF
--- a/brax/training/agents/ppo/train.py
+++ b/brax/training/agents/ppo/train.py
@@ -267,6 +267,7 @@ def make_train_space(environment: envs.Env,
   train_space.training_epoch_with_timing = training_epoch_with_timing
   train_space.num_timesteps = num_timesteps
   train_space.seed = seed
+  train_space.max_devices_per_host = max_devices_per_host
 
   key = jax.random.PRNGKey(seed)
   _, local_key = jax.random.split(key)
@@ -293,9 +294,8 @@ def init_training_state(train_space):
   optimizer = train_space.optimizer
   seed = train_space.seed
 
-  #TODO: we should probs uncomment this!
-  # if max_devices_per_host:
-  #   local_devices_to_use = min(local_devices_to_use, max_devices_per_host)
+  if train_space.max_devices_per_host:
+    local_devices_to_use = min(local_devices_to_use, train_space.max_devices_per_host)
 
   key = jax.random.PRNGKey(seed)
   global_key, local_key = jax.random.split(key)

--- a/brax/training/agents/ppo/train.py
+++ b/brax/training/agents/ppo/train.py
@@ -327,6 +327,10 @@ def init_env_state(train_space):
   process_id = jax.process_index()
   local_device_count = jax.local_device_count()
   local_devices_to_use = local_device_count
+  
+  if train_space.max_devices_per_host:
+    local_devices_to_use = min(local_devices_to_use, train_space.max_devices_per_host)
+
 
   key = jax.random.PRNGKey(seed)
   global_key, local_key = jax.random.split(key)
@@ -364,8 +368,9 @@ def train_run(train_space, training_state, env_state):
   process_id = jax.process_index()
   local_device_count = jax.local_device_count()
   local_devices_to_use = local_device_count
-  # if max_devices_per_host:
-  #   local_devices_to_use = min(local_devices_to_use, max_devices_per_host)
+  
+  if train_space.max_devices_per_host:
+    local_devices_to_use = min(local_devices_to_use, train_space.max_devices_per_host)
   logging.info(
       'Device count: %d, process count: %d (id %d), local device count: %d, '
       'devices to be used count: %d', jax.device_count(), process_count,


### PR DESCRIPTION
I refactored the PPO/train code to increase its compatibility with check-pointing and environment variation, while keeping backwards compatibility

This splits the train function into multiple functions:
- make_train_space: a function that creates the training functions, e.g.  training_epoch_with_timing, evaluator, etc... and wraps them in a returned simple namespace
- init_training_state: a function that initializes the training state
- init_env_state: a function that initializes the environment state
- and run_train: a function that performs a training run, when passed a training state, environment state, and train space

This enables the training functions to be run multiple times with jit compilation only occurring once.
This also adds:
- train: a function that works identically to the previous train function, by calling the above described functions
- checkpoint_train: a simple check pointing version of train, that should be compatible with preemption.

The general aim is that run_train should enable people to easily make their own check pointing and environment variation / curriculum generation on top of the Brax PPO training code, without having to modify the Brax PPO code internally.

This is my first pull request, so let me know if I have made any rookie mistakes! And thanks for the great physics engine! 

Fyi, I have not been able to test on in an environment with multiple processors, e.g. a TPU slice