### PR TITLE
fix: fix type hinting for `extra_loss_fns` in mappo

### DIFF
--- a/brax/experimental/composer/training/mappo.py
+++ b/brax/experimental/composer/training/mappo.py
@@ -83,7 +83,7 @@ def compute_ppo_loss(
     lambda_: float = 0.95,
     ppo_epsilon: float = 0.3,
     extra_loss_update_ratios: Optional[Dict[str, float]] = None,
-    extra_loss_fns: Optional[Dict[str, Callable[[ppo.StepData],
+    extra_loss_fns: Optional[Dict[str, Callable[[StepData],
                                                 jnp.ndarray]]] = None,
     action_shapes: Dict[str, Dict[str, Any]] = None,
     agent_name: str = None,


### PR DESCRIPTION
The type hinting for `extra_loss_fns` in `mappo.py` was using the old location of where `StepData` was located.

I noticed this when running the `notebooks/composer/composer.ipynb` because one of the cells would error.