### PR TITLE
fix: fix type hinting for `SimObserver`

### DIFF
--- a/brax/experimental/composer/observers.py
+++ b/brax/experimental/composer/observers.py
@@ -123,7 +123,7 @@ class SimObserver(Observer):
                sdname: str = '',
                comp_name: str = '',
                name: str = None,
-               indices: Tuple[int] = None,
+               indices: Tuple[int, ...] = None,
                **kwargs):
     sdname = component_editor.concat_name(sdname, comp_name)
     if not name:


### PR DESCRIPTION
Corrected the type hinting for the `SimObserver` `indices` argument.