### PR TITLE
Fix jax.dlpack import in brax/io/torch.py.

### DIFF
--- a/brax/io/torch.py
+++ b/brax/io/torch.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Union
 import warnings
 
 import jax
+import jax.dlpack as dlp
 from jax.interpreters.xla import DeviceArray
 
 try:
@@ -49,7 +50,7 @@ def torch_to_jax(value: Any) -> Any:
 def _tensor_to_jax(value: torch.Tensor) -> DeviceArray:
   """Converts a PyTorch Tensor into a Jax DeviceArray."""
   tensor = torch_dlpack.to_dlpack(value)
-  tensor = jax.dlpack.from_dlpack(tensor)
+  tensor = dlp.from_dlpack(tensor)
   return tensor
 
 


### PR DESCRIPTION
Fixes issue google/brax#260, which is about the introductory [Brax Training with PyTorch on GPU](https://colab.research.google.com/github/google/brax/blob/main/notebooks/training_torch.ipynb) notebook partially failing to run. Please let me know what you think.