### PR TITLE
Fix the top-k such that the jax and numpy implementations are equivalent

### DIFF
--- a/brax/jumpy.py
+++ b/brax/jumpy.py
@@ -475,13 +475,13 @@ def segment_sum(data: ndarray,
 
 
 def top_k(operand: ndarray, k: int) -> ndarray:
-  """Returns top k values and their indices along the last axis of operand."""
+  """Returns the oredered top k values and their indices along the last axis of operand."""
   if _which_np(operand) is jnp:
     return jax.lax.top_k(operand, k)
   else:
-    ind = onp.argpartition(operand, -k)[-k:]
-    return operand[ind], ind
-
+    top_ind = onp.argpartition(operand, -k)[-k:]
+    sorted_ind = top_ind[onp.argsort(-operand[top_ind])]
+    return operand[sorted_ind], sorted_ind
 
 def stack(x: List[ndarray], axis=0) -> ndarray:
   """Join a sequence of arrays along a new axis."""

--- a/brax/jumpy.py
+++ b/brax/jumpy.py
@@ -475,7 +475,7 @@ def segment_sum(data: ndarray,
 
 
 def top_k(operand: ndarray, k: int) -> ndarray:
-  """Returns the oredered top k values and their indices along the last axis of operand."""
+  """Returns the ordered top k values and their indices along the last axis of operand."""
   if _which_np(operand) is jnp:
     return jax.lax.top_k(operand, k)
   else:


### PR DESCRIPTION
I have been adding testing to the Farama foundation jumpy fork, https://github.com/Farama-Foundation/Jumpy and found that the top-k jax and numpy implementations are not equivalent.
The jax (and tf) implementations return an ordered top-k and indices. 

This PR makes the top-k function equivalent for numpy and jax

```python
@pytest.mark.parametrize(
    "x, k, ret",
    [
        (jp.array([5, 7, 1, 2]), 2, ([7, 5], [1, 0])),
        (jp.array([5, 9, 7, 1, 2]), 3, ([9, 7, 5], [1, 2, 0])),
        # Jax array
        (jp.array([5, 7, 1, 2], dtype=jnp.int32), 2, ([7, 5], [1, 0])),
        (jp.array([5, 9, 7, 1, 2], dtype=jnp.int32), 3, ([9, 7, 5], [1, 2, 0])),
    ],
)
def test_top_k(x, k, ret):
    """Checks if the result of `top_k` on the given inputs equals the expected output."""
    top, indices = jp.top_k(x, k)
    assert len(top) == len(indices) == len(ret[0]) == len(ret[1])
    assert onp.array_equal(top, ret[0])
    # Checks that the index values in x are equal to the top values.
    assert all(t == x[i] for t, i in zip(top, indices))
```
