### PR TITLE
Added loading mass and joint limits in URDF model importer.

### DIFF
--- a/brax/tests/urdf_test.py
+++ b/brax/tests/urdf_test.py
@@ -76,7 +76,8 @@ class UrdfTest(absltest.TestCase):
     self.assertEqual(config.joints[0].name, 'test_joint')
     self.assertEqual(len(config.actuators), 1)
     self.assertEqual(config.actuators[0].name, 'test_joint')
-
+    self.assertEqual(config.bodies[0].mass, 1.0)
+    self.assertEqual(config.bodies[1].mass, 2.0)
 
 if __name__ == '__main__':
   absltest.main()

--- a/brax/tests/urdf_test.py
+++ b/brax/tests/urdf_test.py
@@ -26,6 +26,8 @@ _TEST_XML = """
 		<dynamics damping="1.0" friction="0.0001" />
 		<origin rpy="1.57080 0.0 1.57080" xyz="0.1 0.2 -0.3" />
 		<axis xyz="1.00000 0.00000 0.00000" />
+    <limit effort="0" lower="0" upper="1" velocity="50"/>
+    <dynamics damping="1.0" friction="0.0001"/>
 	</joint>
   <link name="parent_link">
       <inertial>
@@ -74,6 +76,8 @@ class UrdfTest(absltest.TestCase):
     self.assertEqual(config.bodies[1].name, 'child_link')
     self.assertEqual(len(config.joints), 1)
     self.assertEqual(config.joints[0].name, 'test_joint')
+    self.assertEqual(config.joints[0].angle_limit[0].min, 0)
+    self.assertEqual(config.joints[0].angle_limit[0].max, 1)
     self.assertEqual(len(config.actuators), 1)
     self.assertEqual(config.actuators[0].name, 'test_joint')
     self.assertEqual(config.bodies[0].mass, 1.0)

--- a/brax/tools/urdf.py
+++ b/brax/tools/urdf.py
@@ -199,6 +199,7 @@ class UrdfConverter(object):
       cur_offset: An optional positional offset for this node
     """
     colliders = self.links[node].findall('collision')
+    inertia = self.links[node].find('inertial')
     if fuse_to_parent:
       body = fuse_to_parent
     else:
@@ -253,8 +254,13 @@ class UrdfConverter(object):
 
       else:
         warnings.warn(f'No collider found on link {node}.')
-    # TODO: load real mass and inertia
-    body.mass += 1.
+    
+    if inertia.find("mass") is None:
+      body.mass += 1.
+    else:
+      body.mass = float(inertia.find("mass").get("value"))
+
+    # TODO: load inertia
     body.inertia.x, body.inertia.y, body.inertia.z = 1., 1., 1.
 
     if self.body_tree[node]['joints']:

--- a/brax/tools/urdf.py
+++ b/brax/tools/urdf.py
@@ -131,7 +131,7 @@ def _construct_mesh(geom, pos, rot):
       position=_vec(pos))
 
 
-_joint_type_to_limit = {'revolute': 1, 'universal': 2, 'spherical': 3}
+_joint_type_to_limit = {'universal': 2, 'spherical': 3}
 
 
 class UrdfConverter(object):
@@ -301,11 +301,19 @@ class UrdfConverter(object):
           joint.angular_damping = 10.
           joint.reference_rotation.x, joint.reference_rotation.y, joint.reference_rotation.z = relative_rotation
 
+          limits = self.joints[j['joint']].find('limit')
+
           # TODO: Load joint limit metadata
           if joint_type in _joint_type_to_limit:
             num_limits = _joint_type_to_limit[joint_type]
             for _ in range(num_limits):
               joint.angle_limit.add()
+          elif joint_type == 'revolute':
+            lower = float(limits.get('lower'))
+            upper = float(limits.get('upper'))
+            angle_limit = joint.angle_limit.add()
+            angle_limit.min = lower
+            angle_limit.max = upper
 
           self.expand_node(
               j['child'], cur_quat=quaternions.qmult(rotation, cur_quat))


### PR DESCRIPTION
I have added mass property in URDF and upper/lower revolute joint to Brax model importer.

Test updated accordingly.

I have not added the properties for inertia since the internal model config differs from the [official one](http://wiki.ros.org/urdf/Tutorials/Adding%20Physical%20and%20Collision%20Properties%20to%20a%20URDF%20Model), being the official one a 3x3 matrix.

Inertia property in Body is as a Vector3, I guess changing it to a matrix 3x3 can break other parts of the engine, if this change should be made I would gladly take it.

https://github.com/google/brax/blob/7eaa16b4bf446b117b538dbe9c9401f97cf4afa2/brax/physics/config.proto#L24-L35

<br/>

How would the other limit properties fit in the engine computations? I tried to look for effort and velocity.

I saw limit_strength but without being sure of the units it used I didn't want to break anything.

For the case of velocity I did not find any similar parameter in the back end, are joints speed limited?
<br/>
Regarding joint types "universal" and "spherical" it was not clear to me how are they written in URDF, they are not official. I saw similar ones in Gazebo, SDF and MuJoCo. Due to this I left them as they were.
<br/>
