### PR TITLE
Install files in brax/v2/io and brax/v2/envs/assets required in non-editable installations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include brax/v2/envs/assets/*.xml

--- a/brax/v2/io/__init__.py
+++ b/brax/v2/io/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The Brax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
Without this change, many tests are failing after a non-editable installation with error:
~~~
2023-01-14T18:47:29.8721847Z _________________ ERROR collecting v2/spring/pipeline_test.py __________________
2023-01-14T18:47:29.8723983Z ImportError while importing test module '$PREFIX/lib/python3.10/site-packages/brax/v2/spring/pipeline_test.py'.
2023-01-14T18:47:29.8725020Z Hint: make sure your test modules/packages have valid Python names.
2023-01-14T18:47:29.8725639Z Traceback:
2023-01-14T18:47:29.8726594Z ../_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.10/importlib/__init__.py:126: in import_module
2023-01-14T18:47:29.8727869Z     return _bootstrap._gcd_import(name[level:], package, level)
2023-01-14T18:47:29.8729232Z ../_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.10/site-packages/brax/v2/spring/pipeline_test.py:20: in <module>
2023-01-14T18:47:29.8730502Z     from brax.v2 import test_utils
2023-01-14T18:47:29.8731783Z ../_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.10/site-packages/brax/v2/test_utils.py:22: in <module>
2023-01-14T18:47:29.8733083Z     from brax.v2.io import mjcf
2023-01-14T18:47:29.8733733Z E   ModuleNotFoundError: No module named 'brax.v2.io'
~~~

To reproduce:
~~~
# Run in an appropriate virtualenv or conda env
cd ~
git clone https://github.com/google/brax
cd brax
pip install .
# Navigate to a different directory to avoid cross-talking with the source directory
cd ~
mkdir testbrax
cd testbrax
pytest --pyargs brax -v
~~~

I guess the CI did not catched this error as it is only testing the editable install.