### PR TITLE
Add missing etils dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "absl-py",
         "dataclasses",
         "dm_env",
+        "etils",
         "flax",
         "grpcio",
         "gym",


### PR DESCRIPTION
The etils package is required in several part of the code (https://github.com/search?q=repo%3Agoogle%2Fbrax%20etils&type=code), but it is listed in the dependency of the `setup.py` script. This PR adds etils to the dependency listed in the `setup.py`.