### PR TITLE
Writer: replace add_scalars with add_scalar

### DIFF
--- a/brax/io/metrics.py
+++ b/brax/io/metrics.py
@@ -50,4 +50,4 @@ class Writer:
     ]
     logging.info('[%d] %s', step, ', '.join(values))
     for k, v in scalars.items():
-      self._writer.add_scalars(k, {k: v}, step)
+      self._writer.add_scalar(k, v, step)


### PR DESCRIPTION
Both functions show the logged values in Tensorboard, however 'add_scalar' is much cleaner: 
Previously add_scalars would create a new run folder for each tag, and the description would contain the key twice (e.g. key='eval/reward' results in description: run/eval/reward/**eval/reward**). This resulted in Tensorboard showing multiple runs while actually only doing a single run with different tags. 

The new method can be combined with the old method since both will still write to the same summaryboard.