### PR TITLE
Fix implementation of Transform.inv()

### DIFF
--- a/brax/v2/base.py
+++ b/brax/v2/base.py
@@ -130,9 +130,10 @@ class Transform(Base):
     rot = math.quat_mul(math.quat_inv(t.rot), self.rot)
     return Transform(pos=pos, rot=rot)
 
-  def inv(self):
+  def inv(self) -> 'Transform':
     """Invert the transform."""
-    return Transform(pos=-1.0 * self.pos, rot=math.quat_inv(self.rot))
+    inv_rot = math.quat_inv(self.rot)
+    return Transform(pos=math.rotate(-self.pos, inv_rot), rot=inv_rot)
 
   @classmethod
   def create(

--- a/brax/v2/math_test.py
+++ b/brax/v2/math_test.py
@@ -16,7 +16,7 @@
 
 from absl.testing import absltest
 from absl.testing import parameterized
-from brax.v2 import math
+from brax.v2 import base, math
 import jax
 from jax import numpy as jp
 import numpy as np
@@ -79,6 +79,26 @@ class OrthoganalsTest(parameterized.TestCase):
     self.assertAlmostEqual(np.abs(a.dot(b)), 0, 6)
     self.assertAlmostEqual(np.abs(b.dot(c)), 0, 6)
     self.assertAlmostEqual(np.abs(a.dot(c)), 0, 6)
+
+
+class TransformInvTest(parameterized.TestCase):
+  """Tests Transform.inv()."""
+
+  @parameterized.parameters(range(100))
+  def test_transform_inv(self, i):
+    np.random.seed(i)
+    pos = np.random.randn(3)
+    rot = np.random.randn(4)
+    rot /= np.linalg.norm(rot)
+
+    a = base.Transform(pos, rot)
+    b = a.inv().do(a)
+    c = a.do(a.inv())
+
+    np.testing.assert_array_almost_equal(b.pos, np.zeros(3))
+    np.testing.assert_array_almost_equal(b.rot, np.array([1.0, 0.0, 0.0, 0.0]))
+    np.testing.assert_array_almost_equal(c.pos, np.zeros(3))
+    np.testing.assert_array_almost_equal(c.rot, np.array([1.0, 0.0, 0.0, 0.0]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I've been porting some of my research code to Brax v2, and the performance is very good so far! Our code uses rigid body transforms extensively, and we noticed that `Transform.inv()` seems to differ from the textbook formula (as mentioned in #297). 

This pull request:
1) changes the implementation of `brax.v2.base.Transform.inv()` to match [tiny-differentiable-simulator](https://github.com/erwincoumans/tiny-differentiable-simulator/blob/24c1d2a820e4e8a46d2036fe206340615085c8ef/src/math/transform.hpp#L191) and [MuJoCo](https://github.com/deepmind/mujoco/blob/50bebcb4ee78a3f29644cd081e9f570baf9e4e06/src/engine/engine_util_spatial.c#L302)
2) adds a test case at the end of `brax/v2/math_test.py` (please feel free to move to an appropriate place)