### PR TITLE
Fix the dependency on dataclasses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     scripts=["bin/learn"],
     install_requires=[
         "absl-py",
-        "dataclasses",
+        "dataclasses; python_version < '3.7'",
         "dm_env",
         "etils",
         "flask",


### PR DESCRIPTION
Only require dataclasses if python<3.7.

As of python 3.7, dataclasses is a built-in library. Newer versions of dataclasses require python<3.7 (ericvsmith/dataclasses@44724c4). If dataclasses is required in python>=3.7, the older version of dataclasses (with bugs) will be forced to install, which is useless and not expected.