### PR TITLE
fix camera z fighting bug in viewer

### DIFF
--- a/brax/v1/js/viewer.js
+++ b/brax/v1/js/viewer.js
@@ -59,7 +59,7 @@ class Viewer {
 
     this.domElement.appendChild(this.renderer.domElement);
 
-    this.camera = new THREE.PerspectiveCamera(40, 1, 0.01, 100);
+    this.camera = new THREE.PerspectiveCamera(40, 1, 0.1, 100);
     if (system.config.frozen?.position?.z) {
       this.camera.position.set(0, 0, 1);
     } else if (system.config.frozen?.position?.y) {


### PR DESCRIPTION
This fixing a depth fighting / flickering issue in the viewer when objects are clipping through the ground plane.

Before:


https://user-images.githubusercontent.com/5448363/230492454-8d1609b0-cf2a-4fa2-9ef0-4a5176e61da9.mp4


After:


https://user-images.githubusercontent.com/5448363/230492474-714f9e10-4d43-4457-95e1-7ac68901737a.mp4

