### PR TITLE
Add inclusion of test URDF files in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include brax/envs/assets/*.xml
-recursive-include brax/test_data *.xml *.stl *.obj
+recursive-include brax/test_data *.xml *.stl *.obj *.urdf
 recursive-include brax/visualizer *


### PR DESCRIPTION
Without this fix, the test on the installed (in a non-editable way) brax package fail with:
~~~
2023-04-26T10:15:12.5536862Z FAILED io/mjcf_test.py::MjcfTest::test_load_urdf - FileNotFoundError: [Errno 2] No such file or directory: '$PREFIX/lib/python3.10/site-packages/brax/envs/assets/laikago/laikago_toes_zup.urdf'
~~~
error.

Similar to https://github.com/google/brax/pull/292/files .