### PR TITLE
io/image: Replace PyTinyrenderer with a Pure JAX renderer

### DIFF
--- a/brax/io/image.py
+++ b/brax/io/image.py
@@ -15,7 +15,7 @@
 """Exports a system config and state as an image."""
 
 import io
-from typing import List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Sequence
 
 import brax
 from brax import base
@@ -27,8 +27,9 @@ from PIL import Image
 from renderer import CameraParameters as Camera
 from renderer import LightParameters as Light
 from renderer import Model as RendererMesh
+from renderer import ModelObject as Instance
 from renderer import ShadowParameters as Shadow
-from renderer import Renderer, Scene, UpAxis, transpose_for_display
+from renderer import Renderer, UpAxis, create_capsule, create_cube, transpose_for_display
 import trimesh
 
 
@@ -43,18 +44,33 @@ def grid(grid_size, color):
 
 _GROUND = grid(100, [200, 200, 200])
 
+class Obj(NamedTuple):
+  """An object to be rendered in the scene.
 
-def _scene(sys: brax.System, state: brax.State) -> Tuple[Scene, List[int]]:
-  """Converts a brax System and state to a jaxrenderer scene and instances."""
-  scene = Scene()
-  instances = []
+  Assume the system is unchanged throughout the rendering.
+
+  col is accessed from the batched geoms `sys.geoms`, representing one geom.
+  """
+  instance: Instance
+  """An instance to be rendered in the scene, defined by jaxrenderer."""
+  link_idx: int
+  """col.link_idx if col.link_idx is not None else -1"""
+  off: jp.ndarray
+  """col.transform.rot"""
+  rot: jp.ndarray
+  """col.transform.rot"""
+
+def _build_objects(sys: brax.System) -> List[Obj]:
+  """Converts a brax System to a list of Obj."""
+  objs: List[Obj] = []
 
   def take_i(obj, i):
     return jax.tree_map(lambda x: jp.take(x, i, axis=0), obj)
 
+  link_names: List[str]
   link_names = [n or f'link {i}' for i, n in enumerate(sys.link_names)]
   link_names += ['world']
-  link_geoms = {}
+  link_geoms: Dict[str, List[Any]] = {}
   for batch in sys.geoms:
     num_geoms = len(batch.friction)
     for i in range(num_geoms):
@@ -64,62 +80,87 @@ def _scene(sys: brax.System, state: brax.State) -> Tuple[Scene, List[int]]:
   for _, geom in link_geoms.items():
     for col in geom:
       tex = col.rgba[:3].reshape((1, 1, 3))
+      # reference: https://github.com/erwincoumans/tinyrenderer/blob/89e8adafb35ecf5134e7b17b71b0f825939dc6d9/model.cpp#L215
+      specular_map = jax.lax.full(tex.shape[:2], 2.0)
+
       if isinstance(col, base.Capsule):
         half_height = col.length / 2
-        scene, model = scene.add_capsule(
+        model = create_capsule(
           radius=col.radius,
           half_height=half_height,
           up_axis=UpAxis.Z,
           diffuse_map=tex,
+          specular_map=specular_map,
         )
       elif isinstance(col, base.Box):
-        scene, model = scene.add_cube(
+        model = create_cube(
           half_extents=col.halfsize,
           diffuse_map=tex,
-          texture_scaling=16.,
+          texture_scaling=jp.array(16.),
+          specular_map=specular_map,
         )
       elif isinstance(col, base.Sphere):
-        scene, model = scene.add_capsule(
+        model = create_capsule(
           radius=col.radius,
-          half_height=0.,
+          half_height=jp.array(0.),
           up_axis=UpAxis.Z,
           diffuse_map=tex,
+          specular_map=specular_map,
         )
       elif isinstance(col, base.Plane):
         tex = _GROUND
-        scene, model = scene.add_cube(
-          half_extents=[1000.0, 1000.0, 0.0001],
+        model = create_cube(
+          half_extents=jp.array([1000.0, 1000.0, 0.0001]),
           diffuse_map=tex,
-          texture_scaling=8192.,
+          texture_scaling=jp.array(8192.),
+          specular_map=specular_map,
         )
       elif isinstance(col, base.Convex):
         # convex objects are not visual
         continue
       elif isinstance(col, base.Mesh):
         tm = trimesh.Trimesh(vertices=col.vert, faces=col.face)
-        mesh = RendererMesh.create(
+        model = RendererMesh.create(
             verts=tm.vertices,
             norms=tm.vertex_normals,
             uvs=jp.zeros((tm.vertices.shape[0], 2), dtype=int),
             faces=tm.faces,
             diffuse_map=tex,
         )
-        scene, model = scene.add_model(mesh)
       else:
         raise RuntimeError(f'unrecognized collider: {type(col)}')
 
-      i = col.link_idx if col.link_idx is not None else -1
-      x = state.x.concatenate(base.Transform.zero((1,)))
-      scene, instance = scene.add_object_instance(model)
+      i: int = col.link_idx if col.link_idx is not None else -1
+      instance = Instance(model=model)
       off = col.transform.pos
-      pos = x.pos[i] + math.rotate(off, x.rot[i])
       rot = col.transform.rot
-      rot = math.quat_mul(x.rot[i], rot)
-      scene = scene.set_object_position(instance, pos)
-      scene = scene.set_object_orientation(instance, rot)
-      instances.append(instance)
+      obj = Obj(instance=instance, link_idx=i, off=off, rot=rot)
 
-  return scene, instances
+      objs.append(obj)
+
+  return objs
+
+def _with_state(objs: Iterable[Obj], x: brax.Transform) -> List[Instance]:
+  """x must has at least 1 element. This can be ensured by calling
+    `x.concatenate(base.Transform.zero((1,)))`. x is `state.x`.
+
+    This function does not modify any inputs, rather, it produces a new list of
+    `Instance`s.
+  """
+  if (len(x.pos.shape), len(x.rot.shape)) != (2, 2):
+    raise RuntimeError('unexpected shape in state')
+
+  instances: List[Instance] = []
+  for obj in objs:
+    i = obj.link_idx
+    pos = x.pos[i] + math.rotate(obj.off, x.rot[i])
+    rot = math.quat_mul(x.rot[i], obj.rot)
+    instance = obj.instance
+    instance = instance.replace_with_position(pos)
+    instance = instance.replace_with_orientation(rot)
+    instances.append(instance)
+
+  return instances
 
 
 def _eye(sys: brax.System, state: brax.State) -> List[float]:
@@ -136,6 +177,10 @@ def _up(unused_sys: brax.System) -> List[float]:
   return [0., 0., 1.]
 
 
+def get_target(state: brax.State) -> jp.ndarray:
+  """Gets target of camera."""
+  return jp.array([state.x.pos[0, 0], state.x.pos[0, 1], 0])
+
 def get_camera(
     sys: brax.System, state: brax.State, width: int, height: int, ssaa: int = 2
 ) -> Camera:
@@ -143,7 +188,7 @@ def get_camera(
   eye, up = _eye(sys, state), _up(sys)
   hfov = 58.0
   vfov = hfov * height / width
-  target = [state.x.pos[0, 0], state.x.pos[0, 1], 0]
+  target = get_target(state)
   camera = Camera(
       viewWidth=width * ssaa,
       viewHeight=height * ssaa,
@@ -156,6 +201,48 @@ def get_camera(
 
 
 @jax.default_matmul_precision("float32")
+def render_instances(
+  instances: Sequence[Instance],
+  width: int,
+  height: int,
+  camera: Camera,
+  light: Optional[Light] = None,
+  shadow: Optional[Shadow] = None,
+  camera_target: Optional[jp.ndarray] = None,
+  enable_shadow: bool = True,
+) -> jp.ndarray:
+  """Renders an RGB array of sequence of instances.
+
+  Rendered result is not transposed with `transpose_for_display`; it is in
+  floating numbers in [0, 1], not `uint8` in [0, 255].
+  """
+  if light is None:
+    direction = jp.array([0.57735, -0.57735, 0.57735])
+    light = Light(
+        direction=direction,
+        ambient=0.8,
+        diffuse=0.8,
+        specular=0.6,
+    )
+  if shadow is None and enable_shadow:
+    assert camera_target is not None, 'camera_target is None'
+    shadow = Shadow(centre=camera_target)
+  elif not enable_shadow:
+    shadow = None
+
+  img = Renderer.get_camera_image(
+    objects=instances,
+    light=light,
+    camera=camera,
+    width=width,
+    height=height,
+    shadow_param=shadow,
+  )
+  arr = jax.lax.clamp(0., img, 1.)
+
+  return arr
+
+@jax.default_matmul_precision("float32")
 def render_array(sys: brax.System,
                  state: brax.State,
                  width: int,
@@ -166,42 +253,23 @@ def render_array(sys: brax.System,
                  shadow: Optional[Shadow] = None,
                  enable_shadow: bool = True) -> onp.ndarray:
   """Renders an RGB array of a brax system and QP."""
-  if (len(state.x.pos.shape), len(state.x.rot.shape)) != (2, 2):
-    raise RuntimeError('unexpected shape in state')
-  scene, instances = _scene(sys, state)
-  target = state.x.pos[0, :]
-  if light is None:
-    direction = [0.57735, -0.57735, 0.57735]
-    light = Light(
-        direction=direction,
-        ambient=0.8,
-        diffuse=0.8,
-        specular=0.6,
-    )
+  objs = _build_objects(sys)
+  instances = _with_state(objs, state.x.concatenate(base.Transform.zero((1,))))
+
   if camera is None:
-    eye, up = _eye(sys, state), _up(sys)
-    hfov = 58.0
-    vfov = hfov * height / width
-    camera = Camera(
-        viewWidth=width * ssaa,
-        viewHeight=height * ssaa,
-        position=eye,
-        target=target,
-        up=up,
-        hfov=hfov,
-        vfov=vfov)
-  if shadow is None and enable_shadow:
-    shadow = Shadow(centre=camera.target)
-  objects = [scene.objects[inst] for inst in instances]
-  img = Renderer.get_camera_image(
-    objects=objects,
-    light=light,
+    camera = get_camera(sys, state, width, height, ssaa)
+
+  img = render_instances(
+    instances=instances,
+    width=width * ssaa,
+    height=height * ssaa,
     camera=camera,
-    width=camera.viewWidth,
-    height=camera.viewHeight,
-    shadow_param=shadow,
+    light=light,
+    shadow=shadow,
+    camera_target=get_target(state),
+    enable_shadow=enable_shadow,
   )
-  arr = transpose_for_display(jax.lax.clamp(0., img * 255, 255.).astype(jp.uint8))
+  arr = transpose_for_display((img * 255).astype(jp.uint8))
   if ssaa > 1:
     arr = onp.asarray(Image.fromarray(onp.asarray(arr)).resize((width, height)))
   else:
@@ -216,18 +284,42 @@ def render(sys: brax.System,
            light: Optional[Light] = None,
            cameras: Optional[List[Camera]] = None,
            ssaa: int = 2,
-           fmt='png') -> bytes:
+           fmt='png',
+           shadow: Optional[Shadow] = None,
+           enable_shadow: bool = True) -> bytes:
   """Returns an image of a brax system and QP."""
   if not states:
     raise RuntimeError('must have at least one qp')
   if cameras is None:
-    cameras = [None] * len(states)
+    cameras = [get_camera(sys, state, width, height, ssaa) for state in states]
 
-  frames = [
-      Image.fromarray(
-          render_array(sys, state, width, height, light, camera, ssaa))
-      for state, camera in zip(states, cameras)
-  ]
+  objs = _build_objects(sys)
+  _render = jax.jit(
+    render_instances,
+    static_argnames=("width", "height", "enable_shadow"),
+  )
+  frames: List[Image.Image] = []
+  for state, camera in zip(states, cameras):
+    x = state.x.concatenate(base.Transform.zero((1,)))
+    instances = _with_state(objs, x)
+    target = state.x.pos[0, :]
+    img = _render(
+      instances=instances,
+      width=width * ssaa,
+      height=height * ssaa,
+      camera=camera,
+      light=light,
+      shadow=shadow,
+      camera_target=get_target(state),
+      enable_shadow=enable_shadow,
+    )
+    arr = transpose_for_display((img * 255).astype(jp.uint8))
+    frame = Image.fromarray(onp.asarray(arr))
+    if ssaa > 1:
+      frame = frame.resize((width, height))
+
+    frames.append(frame)
+
   f = io.BytesIO()
   if len(frames) == 1:
     frames[0].save(f, format=fmt)

--- a/brax/io/image.py
+++ b/brax/io/image.py
@@ -155,6 +155,7 @@ def get_camera(
   return camera
 
 
+@jax.default_matmul_precision("float32")
 def render_array(sys: brax.System,
                  state: brax.State,
                  width: int,

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "jax>=0.4.6",
         "jaxlib>=0.4.6",
         "jaxopt",
-        "jaxrenderer>=0.1.3",
+        "jaxrenderer>=0.2.0",
         "jinja2",
         "mujoco",
         "numpy",

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "jax>=0.4.6",
         "jaxlib>=0.4.6",
         "jaxopt",
+        "jaxrenderer>=0.1.3",
         "jinja2",
         "mujoco",
         "numpy",


### PR DESCRIPTION
This solves #331 #108 #47 #67 and is involved in #302

[Example Colab](https://colab.research.google.com/drive/14uV9ORm44lDNxmyjOvpOgGX-o-EVgkhS) (adopt majority of the code from Brax teams's [Brax Training](https://colab.research.google.com/github/google/brax/blob/main/notebooks/training.ipynb))

<s>Known issue: the plane may not display in full correctly, due to unclipped vertices behind/at the camera plane. This will be solved once a proper clipping algorithm is implemented in JaxRenderer (will be delivered soon).</s>
The plane rendering issue is now solved by implementing a rasterisation based on homogeneous interpolation.

Currently this only make changes in the v2 API, with minimal changes. Feel free to tell me if you think it is needed to back port to v1 API as well. I will try to optimise the performance further later.

Update: 
1. with 8a111d9, I jitted the rendering for each frame when renders a batch of states.
2. 828848a refactor batch rendering a bit but with no significant improvement in performance (if there is any), see [simple benchmark here](https://colab.research.google.com/drive/1gBIevFjnRrEpo2uU9blZ5qu6KIzDWTl7)
3. with JoeyTeng/jaxrenderer#2 ([release 0.3.0](https://github.com/JoeyTeng/jaxrenderer/releases/tag/v0.3.0)), the performance is improved to about 10x. Rendering one frame of the `Ant` environment with 960x540 resolution and 1x SSAA is now about [500ms using T4 (0.5 fps)](https://colab.research.google.com/drive/1xhkYNz5WjvUCjQWpp72CLf9SIy3i5PnN#scrollTo=hGLc2_6Kw4_L), and [~70-100ms using A100 (10-14 fps)](https://colab.research.google.com/drive/1A7PzhG3vn6oNzrWTxE5E3dmu8xQTcNnH#scrollTo=hGLc2_6Kw4_L). Previous CPU implementation is about [200ms per frame (5fps)](https://colab.research.google.com/drive/1xhkYNz5WjvUCjQWpp72CLf9SIy3i5PnN#scrollTo=SyVkqzz9oaJA).
4. with JoeyTeng/jaxrenderer#3 ([release 0.3.1](https://github.com/JoeyTeng/jaxrenderer/releases/tag/v0.3.1)), the minimum Python version is lowered to Python 3.8 which is the same as brax.