### PR TITLE
Remove duplicate code in brax.envs by using get_environment

### DIFF
--- a/brax/envs/__init__.py
+++ b/brax/envs/__init__.py
@@ -92,7 +92,7 @@ def create(
   Returns:
     env: an environment
   """
-  env = _envs[env_name](**kwargs)
+  env = get_environment(env_name, **kwargs)
 
   if episode_length is not None:
     env = training.EpisodeWrapper(env, episode_length, action_repeat)

--- a/brax/envs/__init__.py
+++ b/brax/envs/__init__.py
@@ -79,7 +79,7 @@ def create(
     batch_size: Optional[int] = None,
     **kwargs,
 ) -> Env:
-  """Creates an environment from the registry.
+  """Creates an environment with wrappers that depend on the parameters, from the registry.
 
   Args:
     env_name: environment name string


### PR DESCRIPTION
This is a small pull request simply removing code duplication by reusing the `brax.envs.get_environment` function.

I have also made some slight improvements to the documentation of the `brax.envs.create` function to make its difference with the already existing `brax.envs.get_environment` function clearer.