### PR TITLE
Scaling control actions for BRAX environments

### DIFF
--- a/brax/envs/base.py
+++ b/brax/envs/base.py
@@ -26,6 +26,7 @@ from brax.positional import pipeline as p_pipeline
 from brax.spring import pipeline as s_pipeline
 from flax import struct
 import jax
+import jax.numpy as jnp
 import mujoco
 from mujoco import mjx
 import numpy as np
@@ -128,6 +129,22 @@ class PipelineEnv(Env):
       )
 
     return jax.lax.scan(f, pipeline_state, (), self._n_frames)[0]
+  
+  def scale_and_clip_actions(self, action: jax.Array) -> jax.Array:
+    """
+    Scale an input action from `[-1, 1]` up/down to the control limits
+    of each actuator in an the model.
+    
+    We assume the action is in `[-1, 1]` and apply a linear transform
+    to scale the control to `[a, b]` with `u = (u + 1)(b-a)/2 + a`
+    """
+    action_min = self.sys.actuator.ctrl_range[:, 0]
+    action_max = self.sys.actuator.ctrl_range[:, 1]
+    
+    def rescale(x):
+      return (x + 1) * (action_max - action_min) / 2 + action_min
+    
+    return jnp.clip(rescale(action), a_min=action_max, a_max=action_max)
 
   @property
   def dt(self) -> jax.Array:

--- a/brax/envs/humanoid.py
+++ b/brax/envs/humanoid.py
@@ -256,6 +256,7 @@ class Humanoid(PipelineEnv):
   def step(self, state: State, action: jax.Array) -> State:
     """Runs one timestep of the environment's dynamics."""
     pipeline_state0 = state.pipeline_state
+    action = self.scale_and_clip_actions(action)
     pipeline_state = self.pipeline_step(pipeline_state0, action)
 
     com_before, *_ = self._com(pipeline_state0)

--- a/brax/envs/humanoidstandup.py
+++ b/brax/envs/humanoidstandup.py
@@ -219,6 +219,7 @@ class HumanoidStandup(PipelineEnv):
 
   def step(self, state: State, action: jax.Array) -> State:
     """Runs one timestep of the environment's dynamics."""
+    action = self.scale_and_clip_actions(action)
     pipeline_state = self.pipeline_step(state.pipeline_state, action)
 
     pos_after = pipeline_state.x.pos[0, 2]  # z coordinate of torso

--- a/brax/envs/inverted_double_pendulum.py
+++ b/brax/envs/inverted_double_pendulum.py
@@ -46,14 +46,14 @@ class InvertedDoublePendulum(PipelineEnv):
 
   The agent take a 1-element vector for actions.
 
-  The action space is a continuous `(action)` in `[-3, 3]`, where `action`
+  The action space is a continuous `(action)` in `[-1, 1]`, where `action`
   represents the numerical force applied to the cart (with magnitude
   representing the amount of force and sign representing the direction)
 
   | Num | Action                    | Control Min | Control Max | Name (in
   corresponding config) | Joint | Unit      |
   |-----|---------------------------|-------------|-------------|--------------------------------|-------|-----------|
-  | 0   | Force applied on the cart | -3          | 3           | slider
+  | 0   | Force applied on the cart | -1          | 1           | slider
   | slide | Force (N) |
 
   ### Observation Space

--- a/brax/envs/inverted_pendulum.py
+++ b/brax/envs/inverted_pendulum.py
@@ -46,6 +46,9 @@ class InvertedPendulum(PipelineEnv):
   continuous `(action)` in `[-3, 3]`, where `action` represents the numerical
   force applied to the cart (with magnitude representing the amount of force and
   sign representing the direction)
+  
+  Actions are assumed to be within `[-1, 1]` and are (linearly) scaled 
+  to `[-3, 3]` within the environment's `step()` call.
 
   | Num | Action                    | Control Min | Control Max | Name (in
   corresponding config) | Joint | Unit      |
@@ -129,6 +132,7 @@ class InvertedPendulum(PipelineEnv):
 
   def step(self, state: State, action: jax.Array) -> State:
     """Run one timestep of the environment's dynamics."""
+    action = self.scale_and_clip_actions(action)
     pipeline_state = self.pipeline_step(state.pipeline_state, action)
     obs = self._get_obs(pipeline_state)
     reward = 1.0


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/google/brax/issues/472. All environments assume the control action is restricted to `[-1,1]`. 

For the few environments that have an action space that is not `[-1,1]` (`humanoid`, `humanoidstandup`, `pusher`, `inverted_pendulum`), the input action is linearly scaled to the limits of the action space inside the environment's `step()` function.

Please let me know if this is an appropriate solution, I'd be happy to iterate it. Note also that scaling the actions will mean that the "best" hyperparameters for these environments will likely change. Does this need to be addressed anywhere?