### PR TITLE
Updated basic APG algorithm

### DIFF
--- a/brax/training/agents/apg/networks.py
+++ b/brax/training/agents/apg/networks.py
@@ -55,7 +55,8 @@ def make_apg_networks(
     preprocess_observations_fn: types.PreprocessObservationFn = types
     .identity_observation_preprocessor,
     hidden_layer_sizes: Sequence[int] = (32,) * 4,
-    activation: networks.ActivationFn = linen.swish) -> APGNetworks:
+    activation: networks.ActivationFn = linen.elu,
+    layer_norm: bool = True) -> APGNetworks:
   """Make APG networks."""
   parametric_action_distribution = distribution.NormalTanhDistribution(
       event_size=action_size, var_scale=0.1)
@@ -63,7 +64,8 @@ def make_apg_networks(
       parametric_action_distribution.param_size,
       observation_size,
       preprocess_observations_fn=preprocess_observations_fn,
-      hidden_layer_sizes=hidden_layer_sizes, activation=activation)
+      hidden_layer_sizes=hidden_layer_sizes, activation=activation,
+      layer_norm=layer_norm)
   return APGNetworks(
       policy_network=policy_network,
       parametric_action_distribution=parametric_action_distribution)

--- a/brax/training/agents/apg/networks.py
+++ b/brax/training/agents/apg/networks.py
@@ -22,6 +22,7 @@ from brax.training import types
 from brax.training.types import PRNGKey
 import flax
 from flax import linen
+from flax.linen.initializers import orthogonal
 
 
 @flax.struct.dataclass
@@ -65,6 +66,7 @@ def make_apg_networks(
       observation_size,
       preprocess_observations_fn=preprocess_observations_fn,
       hidden_layer_sizes=hidden_layer_sizes, activation=activation,
+      kernel_init = orthogonal(0.01),
       layer_norm=layer_norm)
   return APGNetworks(
       policy_network=policy_network,

--- a/brax/training/agents/apg/networks.py
+++ b/brax/training/agents/apg/networks.py
@@ -58,7 +58,7 @@ def make_apg_networks(
     activation: networks.ActivationFn = linen.swish) -> APGNetworks:
   """Make APG networks."""
   parametric_action_distribution = distribution.NormalTanhDistribution(
-      event_size=action_size)
+      event_size=action_size, var_scale=0.1)
   policy_network = networks.make_policy_network(
       parametric_action_distribution.param_size,
       observation_size,

--- a/brax/training/agents/apg/train.py
+++ b/brax/training/agents/apg/train.py
@@ -67,7 +67,7 @@ def train(
     learning_rate: float = 1e-4,
     adam_b: list = [0.7, 0.95],
     use_schedule: bool = True,
-    use_float64: bool = True,
+    use_float64: bool = False,
     schedule_decay: float = 0.997,
     seed: int = 0,
     max_gradient_norm: float = 1e9,

--- a/brax/training/agents/apg/train_test.py
+++ b/brax/training/agents/apg/train_test.py
@@ -22,10 +22,6 @@ from brax.training.acme import running_statistics
 from brax.training.agents.apg import networks as apg_networks
 from brax.training.agents.apg import train as apg
 import jax
-from jax import config
-config.update("jax_enable_x64", True)
-config.update('jax_default_matmul_precision', jax.lax.Precision.HIGH)
-
 
 class APGTest(parameterized.TestCase):
   """Tests for APG module."""

--- a/brax/training/agents/apg/train_test.py
+++ b/brax/training/agents/apg/train_test.py
@@ -21,7 +21,9 @@ from brax import envs
 from brax.training.acme import running_statistics
 from brax.training.agents.apg import networks as apg_networks
 from brax.training.agents.apg import train as apg
-import jax
+from jax import config
+config.update("jax_enable_x64", True)
+config.update('jax_default_matmul_precision', jax.lax.Precision.HIGH)
 
 
 class APGTest(parameterized.TestCase):
@@ -31,6 +33,7 @@ class APGTest(parameterized.TestCase):
     """Test APG with a simple env."""
     _, _, metrics = apg.train(
         envs.get_environment('fast'),
+        policy_updates=200,
         episode_length=128,
         num_envs=64,
         num_evals=200,
@@ -45,13 +48,14 @@ class APGTest(parameterized.TestCase):
     env = envs.get_environment('fast')
     original_inference, params, _ = apg.train(
         envs.get_environment('fast'),
+        policy_updates=200,
         episode_length=100,
         action_repeat=4,
         num_envs=16,
         learning_rate=3e-3,
         normalize_observations=normalize_observations,
-        num_evals=200,
-        truncation_length=10)
+        num_evals=200
+    )
     normalize_fn = lambda x, y: x
     if normalize_observations:
       normalize_fn = running_statistics.normalize
@@ -86,6 +90,7 @@ class APGTest(parameterized.TestCase):
 
     _, _, _ = apg.train(
         envs.get_environment('inverted_pendulum', backend='spring'),
+        policy_updates=200,
         episode_length=100,
         num_envs=8,
         num_evals=10,

--- a/brax/training/agents/apg/train_test.py
+++ b/brax/training/agents/apg/train_test.py
@@ -21,6 +21,7 @@ from brax import envs
 from brax.training.acme import running_statistics
 from brax.training.agents.apg import networks as apg_networks
 from brax.training.agents.apg import train as apg
+import jax
 from jax import config
 config.update("jax_enable_x64", True)
 config.update('jax_default_matmul_precision', jax.lax.Precision.HIGH)

--- a/brax/training/distribution.py
+++ b/brax/training/distribution.py
@@ -131,7 +131,7 @@ class TanhBijector:
 class NormalTanhDistribution(ParametricDistribution):
   """Normal distribution followed by tanh."""
 
-  def __init__(self, event_size, min_std=0.001):
+  def __init__(self, event_size, min_std=0.001, var_scale=1):
     """Initialize the distribution.
 
     Args:
@@ -151,8 +151,9 @@ class NormalTanhDistribution(ParametricDistribution):
         event_ndims=1,
         reparametrizable=True)
     self._min_std = min_std
+    self._var_scale = var_scale
 
   def create_dist(self, parameters):
     loc, scale = jnp.split(parameters, 2, axis=-1)
-    scale = jax.nn.softplus(scale) + self._min_std
+    scale = (jax.nn.softplus(scale) + self._min_std) * self._var_scale
     return NormalDistribution(loc=loc, scale=scale)

--- a/brax/training/distribution.py
+++ b/brax/training/distribution.py
@@ -137,6 +137,7 @@ class NormalTanhDistribution(ParametricDistribution):
     Args:
       event_size: the size of events (i.e. actions).
       min_std: minimum std for the gaussian.
+      var_scale: adjust the gaussian's scale parameter.
     """
     # We apply tanh to gaussian actions to bound them.
     # Normally we would use TransformedDistribution to automatically

--- a/brax/training/networks.py
+++ b/brax/training/networks.py
@@ -41,6 +41,7 @@ class MLP(linen.Module):
   kernel_init: Initializer = jax.nn.initializers.lecun_uniform()
   activate_final: bool = False
   bias: bool = True
+  layer_norm: bool = False
 
   @linen.compact
   def __call__(self, data: jnp.ndarray):
@@ -54,6 +55,8 @@ class MLP(linen.Module):
               hidden)
       if i != len(self.layer_sizes) - 1 or self.activate_final:
         hidden = self.activation(hidden)
+      if self.layer_norm:
+        hidden = linen.LayerNorm()(hidden)
     return hidden
 
 

--- a/brax/training/networks.py
+++ b/brax/training/networks.py
@@ -42,7 +42,7 @@ class MLP(linen.Module):
   activate_final: bool = False
   bias: bool = True
   layer_norm: bool = False
-
+  
   @linen.compact
   def __call__(self, data: jnp.ndarray):
     hidden = data
@@ -55,8 +55,8 @@ class MLP(linen.Module):
               hidden)
       if i != len(self.layer_sizes) - 1 or self.activate_final:
         hidden = self.activation(hidden)
-      if self.layer_norm:
-        hidden = linen.LayerNorm()(hidden)
+        if self.layer_norm:
+          hidden = linen.LayerNorm()(hidden)
     return hidden
 
 
@@ -89,12 +89,15 @@ def make_policy_network(
     preprocess_observations_fn: types.PreprocessObservationFn = types
     .identity_observation_preprocessor,
     hidden_layer_sizes: Sequence[int] = (256, 256),
-    activation: ActivationFn = linen.relu) -> FeedForwardNetwork:
+    activation: ActivationFn = linen.relu,
+    kernel_init: Initializer = jax.nn.initializers.lecun_uniform(),
+    layer_norm: bool = False) -> FeedForwardNetwork:
   """Creates a policy network."""
   policy_module = MLP(
       layer_sizes=list(hidden_layer_sizes) + [param_size],
       activation=activation,
-      kernel_init=jax.nn.initializers.lecun_uniform())
+      kernel_init=kernel_init,
+      layer_norm=layer_norm)
 
   def apply(processor_params, policy_params, obs):
     obs = preprocess_observations_fn(obs, processor_params)


### PR DESCRIPTION
The goal of this proposed update is to provide a simple APG algorithm that can solve non-trivial tasks, as a first step for researchers and practitioners to explore Brax's differentiable simulation. It has been tested on MJX. Notes:
- A demonstration of this algorithm is shown [here](https://github.com/Andrew-Luo1/mujoco_apg_tutorial/blob/main/mjx/training_apg.ipynb). 
- I have not benchmarked this algorithm against Brax's RL algorithms such as PPO and SAC, since a) the environments would need differentiable rewards, and b) this simple implementation aims to be a basic reference to extend upon.

**1: Algorithm Update**

This fork contains an APG implementation that is about as simple as the current one, but reflects a common thread between several recent results that have used differentiable simulators to achieve locomotion: [1](https://arxiv.org/abs/2204.07137), [2](https://adaptive-horizon-actor-critic.github.io/), [3](https://arxiv.org/abs/2403.14864). 

Brax's current APG algorithm is roughly equivalent to the following pseudocode:
```
for i in range(n_epochs):
    reset state
    policy_grads = []
    for j in range(episode_length // short_horizon))
        state, policy_grad = jax.grad(unroll(state, policy, short_horizon))
        policy_grads.append(policy_grad)
    optimizer.step(mean(policy_grads))
```

In contrast, the cited results update the policy gradient much more frequently, using the observation that policy gradients that differentiate through the simulator have low variance. Hence, unrolling for an entire episode before updating has limited use. That additional samples past a certain point do not help is seen in that convergence does not increase with with massive parallelization [2]. The proposed APG algorithm essentially performs live stochastic gradient descent on the policy, unrolling it for a short window, doing a gradient update, then continuing where it left off:

```
reset state
for i in range(n_epochs):
    state, policy_grad = jax.grad(unroll(state, policy, short_horizon))
    optimizer.step(policy_grad)
```

Note that n_epochs can be much larger in this case. This modification allows the algorithm to relatively quickly learn quadruped locomotion, albeit with a particular training pipeline and reward design. ([Notebook](https://github.com/Andrew-Luo1/mujoco_apg_tutorial/blob/main/mjx/training_apg.ipynb))

Additional notes:
- This fork uses a learning schedule to improve training stability.
- The particular choices of Adam optimizer parameters come from [2] and significantly improve training outcomes.

**2: Supporting Updates**

*Configurable initial policy variance*: When hotstarting a policy, it benefits to explore around its induced state-space vicinity. This can be done by initializing the policy network weights small. Currently, the softplus disables this possibility, so this fork adds a scaling parameter.

*Layer norm*: I have found that using [layer normalization](https://arxiv.org/abs/1607.06450) in the policy neural network has greatly improved the training stability of APG methods and is seen in [other implementations](https://github.com/NVlabs/DiffRL/blob/a4c0dd1696d3c3b885ce85a3cb64370b580cb913/models/actor.py#L32).
