### PR TITLE
Switch gym dependency to gymnasium

### DIFF
--- a/brax/envs/wrappers/gym.py
+++ b/brax/envs/wrappers/gym.py
@@ -17,9 +17,9 @@ from typing import ClassVar, Optional
 
 from brax.envs.base import PipelineEnv
 from brax.io import image
-import gym
-from gym import spaces
-from gym.vector import utils
+import gymnasium as gym
+from gymnasium import spaces
+from gymnasium.vector import utils
 import jax
 import numpy as np
 

--- a/brax/envs/wrappers/gym.py
+++ b/brax/envs/wrappers/gym.py
@@ -17,9 +17,14 @@ from typing import ClassVar, Optional
 
 from brax.envs.base import PipelineEnv
 from brax.io import image
-import gymnasium as gym
-from gymnasium import spaces
-from gymnasium.vector import utils
+try:
+    import gym
+    from gym import spaces
+    from gym.vector import utils
+except ImportError:
+    from gymnasium import gym
+    from gymnasium import spaces
+    from gymnasium.vector import utils
 import jax
 import numpy as np
 

--- a/brax/envs/wrappers/gym.py
+++ b/brax/envs/wrappers/gym.py
@@ -17,14 +17,16 @@ from typing import ClassVar, Optional
 
 from brax.envs.base import PipelineEnv
 from brax.io import image
+
 try:
     import gym
     from gym import spaces
     from gym.vector import utils
 except ImportError:
-    from gymnasium import gym
+    import gymnasium as gym
     from gymnasium import spaces
     from gymnasium.vector import utils
+
 import jax
 import numpy as np
 

--- a/brax/v1/envs/__init__.py
+++ b/brax/v1/envs/__init__.py
@@ -39,7 +39,7 @@ from brax.v1.envs import ur5e
 from brax.v1.envs import walker2d
 from brax.v1.envs import wrappers
 from brax.v1.envs.env import Env, State, Wrapper
-import gym
+import gymnasium as gym
 
 _envs = {
     'acrobot': acrobot.Acrobot,

--- a/brax/v1/envs/__init__.py
+++ b/brax/v1/envs/__init__.py
@@ -39,7 +39,10 @@ from brax.v1.envs import ur5e
 from brax.v1.envs import walker2d
 from brax.v1.envs import wrappers
 from brax.v1.envs.env import Env, State, Wrapper
-import gymnasium as gym
+try:
+  import gym
+except ImportError:
+  import gymnasium as gym
 
 _envs = {
     'acrobot': acrobot.Acrobot,

--- a/brax/v1/envs/wrappers.py
+++ b/brax/v1/envs/wrappers.py
@@ -19,17 +19,16 @@ from typing import ClassVar, Dict, Optional
 
 from brax.v1 import jumpy as jp
 from brax.v1.envs import env as brax_env
-import dm_env
-from dm_env import specs
-import flax
+
 try:
     import gym
     from gym import spaces
     from gym.vector import utils
 except ImportError:
-    from gymnasium import gym
+    import gymnasium as gym
     from gymnasium import spaces
     from gymnasium.vector import utils
+
 import jax
 import jax.numpy as jnp
 

--- a/brax/v1/envs/wrappers.py
+++ b/brax/v1/envs/wrappers.py
@@ -22,9 +22,14 @@ from brax.v1.envs import env as brax_env
 import dm_env
 from dm_env import specs
 import flax
-import gymnasium as gym
-from gymnasium import spaces
-from gymnasium.vector import utils
+try:
+    import gym
+    from gym import spaces
+    from gym.vector import utils
+except ImportError:
+    from gymnasium import gym
+    from gymnasium import spaces
+    from gymnasium.vector import utils
 import jax
 import jax.numpy as jnp
 

--- a/brax/v1/envs/wrappers.py
+++ b/brax/v1/envs/wrappers.py
@@ -22,9 +22,9 @@ from brax.v1.envs import env as brax_env
 import dm_env
 from dm_env import specs
 import flax
-import gym
-from gym import spaces
-from gym.vector import utils
+import gymnasium as gym
+from gymnasium import spaces
+from gymnasium.vector import utils
 import jax
 import jax.numpy as jnp
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "flax",
         # TODO: remove grpcio and gym after dropping legacy v1 code
         "grpcio",
-        "gym",
+        "gymnasium",
         "jax>=0.4.6",
         "jaxlib>=0.4.6",
         "jaxopt",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         "flax",
         # TODO: remove grpcio and gym after dropping legacy v1 code
         "grpcio",
-        "gymnasium",
         "jax>=0.4.6",
         "jaxlib>=0.4.6",
         "jaxopt",
@@ -66,6 +65,8 @@ setup(
     ],
     extras_require={
         "develop": ["pytest", "transforms3d"],
+        "gym": ["gym"],
+        "gymnasium": ["gymnasium"],
     },
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Since `gym` is deprecated in favor of `gymnasium` (see https://github.com/openai/gym?tab=readme-ov-file#important-notice) here I propose the switch, allowing both installation as alternative to keep backwards compatibilty.

This allows for use of python>=3.10, that is incompatible with gym.

Possible fix for #421.