### PR TITLE
Added velocity damping to pusher, fixes #477

### DIFF
--- a/brax/envs/assets/pusher.xml
+++ b/brax/envs/assets/pusher.xml
@@ -14,6 +14,7 @@
     <numeric data="10" name="constraint_ang_damping"/>
     <numeric data="50" name="constraint_vel_damping"/>
     <numeric data="0" name="ang_damping"/>
+    <numeric data="-1" name="vel_damping"/>
     <numeric data="1" name="spring_mass_scale"/>
     <numeric data="1" name="spring_inertia_scale"/>
     <numeric data="10" name="solver_maxls"/>


### PR DESCRIPTION
As described in https://github.com/google/brax/issues/477, currently there is no friction-like force in the ``pusher`` environment with the ``spring`` backend. This means that even a slight touch of the object by the robot leads to the object infinitely sliding off into the distance.

Per suggestion of @btaba in that issue, I added velocity damping, which solved the problem.

Note that  I had to set its value to -1, despite it being set to either 0 or 1 in the Brax codebase. Looking at the integrator.py code shows that having vel_damping > 0 leads to anti-damping, as xd_i.vel is multiplied by exp(positive number) > 1.