### PR TITLE
Rscope: MJX + Brax Reinforcement Learning Debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ To train a model:
 learn
 ```
 
+To interactively visualize trajectories from the current training run using the Mujoco viewer:
+
+```
+python -m brax.rscope
+```
+
+See [here](https://github.com/google/brax/tree/main/brax/training/rscope/README.md) for how to configure this feature.
+
 Training on NVidia GPU is supported, but you must first install
 [CUDA, CuDNN, and JAX with GPU support](https://github.com/google/jax#installation).
 

--- a/brax/__init__.py
+++ b/brax/__init__.py
@@ -20,3 +20,4 @@ from brax.base import Motion
 from brax.base import State
 from brax.base import System
 from brax.base import Transform
+from brax.training.rscope import main as rscope

--- a/brax/envs/wrappers/training.py
+++ b/brax/envs/wrappers/training.py
@@ -217,6 +217,29 @@ class EvalWrapper(Wrapper):
     return nstate
 
 
+class RScopeWrapper(Wrapper):
+  """Used with RScope. Saves fields required for rendering in state.info."""
+  def reset(self, rng: jax.Array) -> State:
+    state = self.env.reset(rng)
+    self._store(state)
+    return state
+  
+  def step(self, state: State, action: jax.Array) -> State:
+      state = self.env.step(state, action)
+      self._store(state)
+      return state
+
+  def _store(self, state: State):
+    state.info['rscope'] = {
+        'qpos': state.data.qpos,
+        'qvel': state.data.qvel,
+        'time': state.data.time,
+        'metrics': state.metrics}
+    if hasattr(state.data, 'mocap_pos') and hasattr(state.data, 'mocap_quat'):
+        state.info['rscope']['mocap_pos'] = state.data.mocap_pos
+        state.info['rscope']['mocap_quat'] = state.data.mocap_quat
+
+
 class DomainRandomizationVmapWrapper(Wrapper):
   """Wrapper for domain randomization."""
 

--- a/brax/training/agents/ppo/train.py
+++ b/brax/training/agents/ppo/train.py
@@ -244,6 +244,7 @@ def train(
     restore_checkpoint_path: Optional[str] = None,
     restore_params: Optional[Any] = None,
     restore_value_fn: bool = True,
+    rscope_envs: Optional[int] = None,
 ):
   """PPO training.
 
@@ -312,6 +313,8 @@ def train(
       from the return values of ppo.train().
     restore_value_fn: whether to restore the value function from the checkpoint
       or use a random initialization
+    rscope_envs: the number of eval trajectories to save. If None, no rscope
+      trajectories are saved.
 
   Returns:
     Tuple of (make_policy function, network params, metrics)
@@ -666,6 +669,7 @@ def train(
       episode_length=episode_length,
       action_repeat=action_repeat,
       key=eval_key,
+      rscope_envs=rscope_envs
   )
 
   # Run initial eval

--- a/brax/training/rscope/README.md
+++ b/brax/training/rscope/README.md
@@ -1,0 +1,62 @@
+## Rscope: MJX + Brax Reinforcement Learning Debugger
+
+![rscope_header](https://github.com/user-attachments/assets/225d0290-501d-4a2e-ace9-f2122786ffb6)
+
+Understanding what your RL agent is learning can be challenging when relying solely on statistics and plots. `rscope` is a lightweight visualizer built on the Mujoco viewer that lets you interactively explore trajectories without adding any training time overhead. It enables you to scroll through and inspect trajectories collected from different parallel environments during training.
+
+Key use cases include:
+- Visualizing the randomization ranges during agent initialization.
+- Determining appropriate scales for reward shaping.
+- Investigating pathological behavior, such as local minima or issues leading to simulator NaNs.
+
+**Features**
+1. View trajectories from various policy checkpoints and parallel environments.
+2. Visualize shaping reward terms.
+3. Display pixel observations for vision-based training.
+4. Utilize Mujoco Viewer functionalities like pan/zoom, toggle wireframe, and view light/camera locations.
+
+### Usage
+Between policy updates, Brax training algorithms evaluate the policy by unrolling parallel environments for a full episode and computing reward statistics. `rscope` then loads and visualizes these evaluation trajectories on the CPU, ensuring that accelerator hardware remains free for the training run.
+
+To use `rscope`, configure your training algorithm to save evaluation trajectories under `/tmp/rscope/active_run`. This setup allows you to view both existing trajectories in the folder and any new ones as they are added.
+
+**Training Script**
+
+*Imports*
+```python
+from brax.training.rscope import rscope_utils
+```
+
+*Within the progress function*
+```python
+# Dumps trajectories from the evaluator run to /tmp/rscope/active_run for visualization
+rscope_utils.dump_eval(metrics['eval/data'])
+```
+
+*Before training begins*
+```python
+# Clears /tmp/rscope/active_run and dumps initial data for rscope to load the model
+rscope_utils.rscope_init(env.xml_path, env.model_assets)
+```
+
+*Training argument*
+```python
+...
+# Save trajectories from environment 0:rscope_envs for visualization
+rscope_envs=16
+...
+```
+
+**CLI**
+```bash
+# Launch rscope
+python -m brax.rscope
+```
+
+### Sharp Bits
+- Currently supports only PPO-based training.
+- Evaluating in **deterministic mode** (`deterministic_eval=True`) shows the policy's capabilities, whereas **stochastic mode** helps gauge training dynamics.
+- Renders incorrectly for domain-randomized training because the loaded assets are from the nominal model definition.
+- Plots only the first 14 keys in the metrics without filtering for shaping rewards.
+- Visualizes only the first 14 pixel observations.
+- Cannot capture curriculum progression during training, as curriculums depend on `state.info`, which is reset at the start of an evaluator run.

--- a/brax/training/rscope/config.py
+++ b/brax/training/rscope/config.py
@@ -1,0 +1,11 @@
+from absl import flags
+import sys
+from pathlib import Path
+
+# Parse command-line flags.
+flags.DEFINE_string("logdir", "/tmp/rscope/active_run", "Path to the rscope directory.")
+flags.FLAGS(sys.argv)
+
+# Global paths.
+BASE_PATH = Path(flags.FLAGS.logdir)
+META_PATH = BASE_PATH / "rscope_meta.pkl"

--- a/brax/training/rscope/config.py
+++ b/brax/training/rscope/config.py
@@ -1,9 +1,28 @@
-from absl import flags
-import sys
+# Copyright 2025 The Brax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rscope configuration."""
+
 from pathlib import Path
+import sys
+
+from absl import flags
 
 # Parse command-line flags.
-flags.DEFINE_string("logdir", "/tmp/rscope/active_run", "Path to the rscope directory.")
+flags.DEFINE_string(
+    "logdir", "/tmp/rscope/active_run", "Path to the rscope directory."
+)
 flags.FLAGS(sys.argv)
 
 # Global paths.

--- a/brax/training/rscope/event_handler.py
+++ b/brax/training/rscope/event_handler.py
@@ -1,8 +1,27 @@
+# Copyright 2025 The Brax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Event handler for Rscope."""
+
 from watchdog.events import FileSystemEventHandler
-from rollout import append_unroll
+
+from brax.training.rscope.rollout import append_unroll
+
 
 class MjUnrollHandler(FileSystemEventHandler):
-    """Handles new .mj_unroll files appearing in the base directory."""
-    def on_created(self, event):
-        if not event.is_directory and event.src_path.endswith(".mj_unroll"):
-            append_unroll(event.src_path)
+  """Handles new .mj_unroll files appearing in the base directory."""
+
+  def on_created(self, event):
+    if not event.is_directory and event.src_path.endswith(".mj_unroll"):
+      append_unroll(event.src_path)

--- a/brax/training/rscope/event_handler.py
+++ b/brax/training/rscope/event_handler.py
@@ -1,0 +1,8 @@
+from watchdog.events import FileSystemEventHandler
+from rollout import append_unroll
+
+class MjUnrollHandler(FileSystemEventHandler):
+    """Handles new .mj_unroll files appearing in the base directory."""
+    def on_created(self, event):
+        if not event.is_directory and event.src_path.endswith(".mj_unroll"):
+            append_unroll(event.src_path)

--- a/brax/training/rscope/image_processing.py
+++ b/brax/training/rscope/image_processing.py
@@ -1,31 +1,48 @@
+# Copyright 2025 The Brax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Image processing utilities."""
+
 import numpy as np
 
+
 def process_img(obs: np.ndarray) -> np.ndarray:
-    """
-    Process an image observation:
-      1. If of float type, clip to [0, 1] and scale to [0, 255] as uint8.
-      2. If single-channel, expand to 3 channels.
-      3. If not square, pad the image to make it square.
-    """
-    # Convert floats to uint8.
-    if np.issubdtype(obs.dtype, np.floating):
-        obs = np.clip(obs, 0, 1)
-        obs = (obs * 255).astype(np.uint8)
-    
-    # Expand single-channel to 3 channels.
-    if len(obs.shape) == 2 or (len(obs.shape) == 3 and obs.shape[2] == 1):
-        if len(obs.shape) == 2:
-            obs = obs[:, :, None]
-        obs = np.repeat(obs, 3, axis=2)
-    
-    # Pad to square if necessary.
-    height, width = obs.shape[0], obs.shape[1]
-    if height != width:
-        max_dim = max(height, width)
-        padded = np.zeros((max_dim, max_dim, obs.shape[2]), dtype=obs.dtype)
-        h_pad = (max_dim - height) // 2
-        w_pad = (max_dim - width) // 2
-        padded[h_pad:h_pad + height, w_pad:w_pad + width, :] = obs
-        obs = padded
-    
-    return obs
+  """
+  Process an image observation:
+    1. If of float type, clip to [0, 1] and scale to [0, 255] as uint8.
+    2. If single-channel, expand to 3 channels.
+    3. If not square, pad the image to make it square.
+  """
+  # Convert floats to uint8.
+  if np.issubdtype(obs.dtype, np.floating):
+    obs = np.clip(obs, 0, 1)
+    obs = (obs * 255).astype(np.uint8)
+
+  # Expand single-channel to 3 channels.
+  if len(obs.shape) == 2 or (len(obs.shape) == 3 and obs.shape[2] == 1):
+    if len(obs.shape) == 2:
+      obs = obs[:, :, None]
+    obs = np.repeat(obs, 3, axis=2)
+
+  # Pad to square if necessary.
+  height, width = obs.shape[0], obs.shape[1]
+  if height != width:
+    max_dim = max(height, width)
+    padded = np.zeros((max_dim, max_dim, obs.shape[2]), dtype=obs.dtype)
+    h_pad = (max_dim - height) // 2
+    w_pad = (max_dim - width) // 2
+    padded[h_pad : h_pad + height, w_pad : w_pad + width, :] = obs
+    obs = padded
+
+  return obs

--- a/brax/training/rscope/image_processing.py
+++ b/brax/training/rscope/image_processing.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+def process_img(obs: np.ndarray) -> np.ndarray:
+    """
+    Process an image observation:
+      1. If of float type, clip to [0, 1] and scale to [0, 255] as uint8.
+      2. If single-channel, expand to 3 channels.
+      3. If not square, pad the image to make it square.
+    """
+    # Convert floats to uint8.
+    if np.issubdtype(obs.dtype, np.floating):
+        obs = np.clip(obs, 0, 1)
+        obs = (obs * 255).astype(np.uint8)
+    
+    # Expand single-channel to 3 channels.
+    if len(obs.shape) == 2 or (len(obs.shape) == 3 and obs.shape[2] == 1):
+        if len(obs.shape) == 2:
+            obs = obs[:, :, None]
+        obs = np.repeat(obs, 3, axis=2)
+    
+    # Pad to square if necessary.
+    height, width = obs.shape[0], obs.shape[1]
+    if height != width:
+        max_dim = max(height, width)
+        padded = np.zeros((max_dim, max_dim, obs.shape[2]), dtype=obs.dtype)
+        h_pad = (max_dim - height) // 2
+        w_pad = (max_dim - width) // 2
+        padded[h_pad:h_pad + height, w_pad:w_pad + width, :] = obs
+        obs = padded
+    
+    return obs

--- a/brax/training/rscope/main.py
+++ b/brax/training/rscope/main.py
@@ -1,0 +1,145 @@
+import time
+from pathlib import Path
+
+import mujoco
+import mujoco.viewer as mujoco_viewer
+import glfw
+
+from config import BASE_PATH
+from model_loader import load_model_and_data
+import rollout
+from event_handler import MjUnrollHandler
+import viewer_utils as vu
+from image_processing import process_img
+from watchdog.observers import Observer
+from state import ViewerState
+
+# Create an instance of ViewerState to encapsulate state.
+viewer_state = ViewerState()
+
+
+# Load the Mujoco model and data.
+mj_model, mj_data, meta = load_model_and_data()
+
+# Load initial unroll files.
+def load_initial_unrolls():
+    unroll_files = rollout.find_unrolls(BASE_PATH)
+    while not unroll_files:
+        print(f"No unrolls found in {BASE_PATH}, waiting...")
+        time.sleep(4)
+        unroll_files = rollout.find_unrolls(BASE_PATH)
+    unroll_files = sorted(unroll_files)
+    for f in unroll_files:
+        rollout.append_unroll(Path(BASE_PATH) / f)
+    print(f"main.py Env dt: {rollout.env_ctrl_dt}")
+
+load_initial_unrolls()
+
+# Setup file system observer.
+event_handler = MjUnrollHandler()
+observer = Observer()
+observer.schedule(event_handler, str(BASE_PATH), recursive=False)
+try:
+    observer.start()
+except Exception as e:
+    print(f"Error starting observer: {e}")
+
+# Initialize figures using metrics keys from the first rollout.
+metrics_keys = list(rollout.rollouts[0].metrics.keys())
+vu.reset_figures(metrics_keys)
+
+# Determine the initial replay length.
+replay_len = rollout.rollouts[0].qpos.shape[0]
+
+with mujoco_viewer.launch_passive(
+        mj_model, mj_data,
+        show_left_ui=False, show_right_ui=False,
+        key_callback=viewer_state.key_callback) as viewer:
+    
+    while viewer.is_running():
+        step_start = time.time()
+        
+        # Trajectory selection: if a new rollout is requested.
+        if viewer_state.change_rollout:
+            vu.reset_figures(metrics_keys)
+            viewer_state.change_rollout = False
+            full_rollout = rollout.rollouts[viewer_state.cur_eval]
+            if isinstance(full_rollout.obs, dict):
+                obs = rollout.dict_obs_pixels_env_select(full_rollout.obs, viewer_state.cur_env)
+            else:
+                obs = full_rollout.obs[:, viewer_state.cur_env]
+            cur_rollout = full_rollout._replace(
+                qpos=full_rollout.qpos[:, viewer_state.cur_env],
+                qvel=full_rollout.qvel[:, viewer_state.cur_env],
+                mocap_pos=full_rollout.mocap_pos[:, viewer_state.cur_env],
+                mocap_quat=full_rollout.mocap_quat[:, viewer_state.cur_env],
+                obs=obs,
+                reward=full_rollout.reward[:, viewer_state.cur_env],
+                time=full_rollout.time[:, viewer_state.cur_env],
+                metrics=rollout.metrics_env_select(full_rollout.metrics, viewer_state.cur_env)
+            )
+            replay_index = 0
+            replay_len = cur_rollout.qpos.shape[0]
+        
+        with viewer.lock():
+            # Overlay text.
+            text_1 = "Eval\nEnv\nStep\nStatus"
+            text_2 = (f"{viewer_state.cur_eval+1}/{rollout.num_evals}\n"
+                     f"{viewer_state.cur_env+1}/{rollout.num_envs}\n"
+                     f"{replay_index}")
+            text_2 += "\nPause" if viewer_state.pause else "\nPlay"
+            overlays = [
+                (mujoco.mjtFontScale.mjFONTSCALE_150,
+                 mujoco.mjtGridPos.mjGRID_TOPLEFT, text_1, text_2)
+            ]
+            if viewer_state.show_help:
+                menu_text_1, menu_text_2 = vu.get_menu_text()
+                overlays.append(
+                    (mujoco.mjtFontScale.mjFONTSCALE_150,
+                     mujoco.mjtGridPos.mjGRID_BOTTOMLEFT, menu_text_1, menu_text_2)
+                )
+            viewer.overlay_text(overlays)
+            
+            # Render figures (metrics).
+            if viewer_state.show_metrics:
+                if not viewer_state.pause:
+                    cur_metrics = {key: metrics[replay_index] for key, metrics in cur_rollout.metrics.items()}
+                    for key in cur_metrics:
+                        vu.add_data_to_fig(key, cur_metrics[key])
+                viewports = vu.get_viewports(len(cur_rollout.metrics), viewer.viewport)
+                viewport_figures = list(zip(viewports, list(vu.figures.values())))
+                viewer.set_figures(viewport_figures)
+            else:
+                viewer.clear_figures()
+            
+            # Render pixel observations if available.
+            from collections.abc import Mapping
+            if isinstance(cur_rollout.obs, Mapping):
+                if any(key.startswith('pixels/') for key in cur_rollout.obs.keys()):
+                    if viewer_state.show_pixel_obs:
+                        cur_obs = rollout.dict_obs_t_select(cur_rollout.obs, replay_index)
+                        viewports = vu.get_viewports(len(cur_obs), viewer.viewport)
+                        processed_obs = {key: process_img(cur_obs[key]) for key in cur_obs.keys()}
+                        viewer.set_images(list(zip(viewports, list(processed_obs.values()))))
+                    else:
+                        viewer.clear_images()
+        
+        # Advance simulation: update the state.
+        def advance_rollout(mj_model, mj_data, idx):
+            mj_data.qpos, mj_data.qvel = cur_rollout.qpos[idx], cur_rollout.qvel[idx]
+            if cur_rollout.mocap_pos.size:
+                mj_data.mocap_pos, mj_data.mocap_quat = cur_rollout.mocap_pos[idx], cur_rollout.mocap_quat[idx]
+            mj_data.time = cur_rollout.time[idx]
+            mujoco.mj_forward(mj_model, mj_data)
+        
+        advance_rollout(mj_model, mj_data, replay_index)
+        if not viewer_state.pause:
+            replay_index = (replay_index + 1) % replay_len
+            viewer.sync()
+        
+        time_until_next_step = float(rollout.env_ctrl_dt) - (time.time() - step_start)
+        if time_until_next_step > 0:
+            time.sleep(time_until_next_step)
+
+observer.stop()
+observer.join()

--- a/brax/training/rscope/model_loader.py
+++ b/brax/training/rscope/model_loader.py
@@ -1,11 +1,32 @@
+# Copyright 2025 The Brax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model loader."""
+
 import pickle
+
 import mujoco
-from config import META_PATH
+
+from brax.training.rscope.config import META_PATH
+
 
 def load_model_and_data():
-    """Load meta information and create the Mujoco model and data."""
-    with open(META_PATH, "rb") as f:
-        meta = pickle.load(f)
-    mj_model = mujoco.MjModel.from_xml_path(meta['xml_path'], assets=meta['model_assets'])
-    mj_data = mujoco.MjData(mj_model)
-    return mj_model, mj_data, meta
+  """Load meta information and create the Mujoco model and data."""
+  with open(META_PATH, 'rb') as f:
+    meta = pickle.load(f)
+  mj_model = mujoco.MjModel.from_xml_path(
+      meta['xml_path'], assets=meta['model_assets']
+  )
+  mj_data = mujoco.MjData(mj_model)
+  return mj_model, mj_data, meta

--- a/brax/training/rscope/model_loader.py
+++ b/brax/training/rscope/model_loader.py
@@ -1,0 +1,11 @@
+import pickle
+import mujoco
+from config import META_PATH
+
+def load_model_and_data():
+    """Load meta information and create the Mujoco model and data."""
+    with open(META_PATH, "rb") as f:
+        meta = pickle.load(f)
+    mj_model = mujoco.MjModel.from_xml_path(meta['xml_path'], assets=meta['model_assets'])
+    mj_data = mujoco.MjData(mj_model)
+    return mj_model, mj_data, meta

--- a/brax/training/rscope/rollout.py
+++ b/brax/training/rscope/rollout.py
@@ -1,19 +1,38 @@
-from typing import NamedTuple, Union, List, Dict
-import pickle
+# Copyright 2025 The Brax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rollout utilities."""
+
 from pathlib import Path
+import pickle
+from typing import Dict, List, NamedTuple, Union
+
 from brax.training.acme.types import NestedArray
 
 MAX_VIEWPORTS = 12
 
+
 class Rollout(NamedTuple):
-    qpos: NestedArray
-    qvel: NestedArray
-    mocap_pos: NestedArray
-    mocap_quat: NestedArray
-    obs: NestedArray
-    reward: NestedArray
-    time: NestedArray
-    metrics: NestedArray
+  qpos: NestedArray
+  qvel: NestedArray
+  mocap_pos: NestedArray
+  mocap_quat: NestedArray
+  obs: NestedArray
+  reward: NestedArray
+  time: NestedArray
+  metrics: NestedArray
+
 
 # Global rollout state.
 rollouts: List[Rollout] = []
@@ -22,68 +41,74 @@ num_envs = 0
 env_ctrl_dt = 0.0
 change_rollout = False
 
+
 def append_unroll(fpath: Union[str, Path]):
-    """Load an unroll file and append it to the list of rollouts."""
-    global num_evals, num_envs, env_ctrl_dt, change_rollout
-    with open(fpath, "rb") as f:
-        transitions = pickle.load(f)
-    raw_rollout = transitions.extras['state_extras']['rscope']
-    assert raw_rollout['qpos'].shape[1] == raw_rollout['qvel'].shape[1], (
-        f"qpos and qvel shapes don't match: {raw_rollout['qpos'].shape} vs {raw_rollout['qvel'].shape}"
-    )
-    num_envs = raw_rollout['qpos'].shape[1]
-    rollouts.append(
-        Rollout(
-            qpos=raw_rollout['qpos'],
-            qvel=raw_rollout['qvel'],
-            mocap_pos=raw_rollout['mocap_pos'],
-            mocap_quat=raw_rollout['mocap_quat'],
-            obs=transitions.observation,
-            reward=transitions.reward,
-            time=raw_rollout['time'],
-            metrics=raw_rollout['metrics']
-        )
-    )
-    num_evals += 1
-    env_ctrl_dt = raw_rollout['time'][1, 0] - raw_rollout['time'][0, 0]
-    if len(rollouts) == 1:
-        change_rollout = True
+  """Load an unroll file and append it to the list of rollouts."""
+  global num_evals, num_envs, env_ctrl_dt, change_rollout
+  with open(fpath, 'rb') as f:
+    transitions = pickle.load(f)
+  raw_rollout = transitions.extras['state_extras']['rscope']
+  assert raw_rollout['qpos'].shape[1] == raw_rollout['qvel'].shape[1], (
+      f"qpos and qvel shapes don't match: {raw_rollout['qpos'].shape} vs"
+      f" {raw_rollout['qvel'].shape}"
+  )
+  num_envs = raw_rollout['qpos'].shape[1]
+  rollouts.append(
+      Rollout(
+          qpos=raw_rollout['qpos'],
+          qvel=raw_rollout['qvel'],
+          mocap_pos=raw_rollout['mocap_pos'],
+          mocap_quat=raw_rollout['mocap_quat'],
+          obs=transitions.observation,
+          reward=transitions.reward,
+          time=raw_rollout['time'],
+          metrics=raw_rollout['metrics'],
+      )
+  )
+  num_evals += 1
+  env_ctrl_dt = raw_rollout['time'][1, 0] - raw_rollout['time'][0, 0]
+  if len(rollouts) == 1:
+    change_rollout = True
+
 
 def find_unrolls(base_path: Union[str, Path]) -> List[str]:
-    """Return a list of filenames in base_path that end with .mj_unroll."""
-    base = Path(base_path)
-    return [f.name for f in base.iterdir() if f.name.endswith(".mj_unroll")]
+  """Return a list of filenames in base_path that end with .mj_unroll."""
+  base = Path(base_path)
+  return [f.name for f in base.iterdir() if f.name.endswith('.mj_unroll')]
+
 
 def dict_obs_pixels_env_select(obs: Dict, i_env: int) -> Dict:
-    """
-    Select the first MAX_VIEWPORTS keys from the observation dictionary
-    that start with 'pixels/' (excluding ones with 'latent') and extract column i_env.
-    """
-    obs_pixels = {}
-    num_shown = 0
-    for key in obs.keys():
-        if num_shown >= MAX_VIEWPORTS:
-            break
-        if key.startswith('pixels/') and 'latent' not in key:
-            obs_pixels[key] = obs[key][:, i_env]
-            num_shown += 1
-    return obs_pixels
+  """
+  Select the first MAX_VIEWPORTS keys from the observation dictionary
+  that start with 'pixels/' (excluding ones with 'latent') and extract column i_env.
+  """
+  obs_pixels = {}
+  num_shown = 0
+  for key in obs.keys():
+    if num_shown >= MAX_VIEWPORTS:
+      break
+    if key.startswith('pixels/') and 'latent' not in key:
+      obs_pixels[key] = obs[key][:, i_env]
+      num_shown += 1
+  return obs_pixels
+
 
 def dict_obs_t_select(obs: Dict, t: int) -> Dict:
-    """
-    Select the first MAX_VIEWPORTS keys from the observation dictionary
-    that start with 'pixels/' (excluding ones with 'latent') and extract index t.
-    """
-    obs_t = {}
-    num_shown = 0
-    for key in obs.keys():
-        if num_shown >= MAX_VIEWPORTS:
-            break
-        if key.startswith('pixels/') and 'latent' not in key:
-            obs_t[key] = obs[key][t]
-            num_shown += 1
-    return obs_t
+  """
+  Select the first MAX_VIEWPORTS keys from the observation dictionary
+  that start with 'pixels/' (excluding ones with 'latent') and extract index t.
+  """
+  obs_t = {}
+  num_shown = 0
+  for key in obs.keys():
+    if num_shown >= MAX_VIEWPORTS:
+      break
+    if key.startswith('pixels/') and 'latent' not in key:
+      obs_t[key] = obs[key][t]
+      num_shown += 1
+  return obs_t
+
 
 def metrics_env_select(metrics: Dict, i_env: int) -> Dict:
-    """Select column i_env from each metric."""
-    return {key: metrics[key][:, i_env] for key in metrics.keys()}
+  """Select column i_env from each metric."""
+  return {key: metrics[key][:, i_env] for key in metrics.keys()}

--- a/brax/training/rscope/rollout.py
+++ b/brax/training/rscope/rollout.py
@@ -1,0 +1,89 @@
+from typing import NamedTuple, Union, List, Dict
+import pickle
+from pathlib import Path
+from brax.training.acme.types import NestedArray
+
+MAX_VIEWPORTS = 12
+
+class Rollout(NamedTuple):
+    qpos: NestedArray
+    qvel: NestedArray
+    mocap_pos: NestedArray
+    mocap_quat: NestedArray
+    obs: NestedArray
+    reward: NestedArray
+    time: NestedArray
+    metrics: NestedArray
+
+# Global rollout state.
+rollouts: List[Rollout] = []
+num_evals = 0
+num_envs = 0
+env_ctrl_dt = 0.0
+change_rollout = False
+
+def append_unroll(fpath: Union[str, Path]):
+    """Load an unroll file and append it to the list of rollouts."""
+    global num_evals, num_envs, env_ctrl_dt, change_rollout
+    with open(fpath, "rb") as f:
+        transitions = pickle.load(f)
+    raw_rollout = transitions.extras['state_extras']['rscope']
+    assert raw_rollout['qpos'].shape[1] == raw_rollout['qvel'].shape[1], (
+        f"qpos and qvel shapes don't match: {raw_rollout['qpos'].shape} vs {raw_rollout['qvel'].shape}"
+    )
+    num_envs = raw_rollout['qpos'].shape[1]
+    rollouts.append(
+        Rollout(
+            qpos=raw_rollout['qpos'],
+            qvel=raw_rollout['qvel'],
+            mocap_pos=raw_rollout['mocap_pos'],
+            mocap_quat=raw_rollout['mocap_quat'],
+            obs=transitions.observation,
+            reward=transitions.reward,
+            time=raw_rollout['time'],
+            metrics=raw_rollout['metrics']
+        )
+    )
+    num_evals += 1
+    env_ctrl_dt = raw_rollout['time'][1, 0] - raw_rollout['time'][0, 0]
+    if len(rollouts) == 1:
+        change_rollout = True
+
+def find_unrolls(base_path: Union[str, Path]) -> List[str]:
+    """Return a list of filenames in base_path that end with .mj_unroll."""
+    base = Path(base_path)
+    return [f.name for f in base.iterdir() if f.name.endswith(".mj_unroll")]
+
+def dict_obs_pixels_env_select(obs: Dict, i_env: int) -> Dict:
+    """
+    Select the first MAX_VIEWPORTS keys from the observation dictionary
+    that start with 'pixels/' (excluding ones with 'latent') and extract column i_env.
+    """
+    obs_pixels = {}
+    num_shown = 0
+    for key in obs.keys():
+        if num_shown >= MAX_VIEWPORTS:
+            break
+        if key.startswith('pixels/') and 'latent' not in key:
+            obs_pixels[key] = obs[key][:, i_env]
+            num_shown += 1
+    return obs_pixels
+
+def dict_obs_t_select(obs: Dict, t: int) -> Dict:
+    """
+    Select the first MAX_VIEWPORTS keys from the observation dictionary
+    that start with 'pixels/' (excluding ones with 'latent') and extract index t.
+    """
+    obs_t = {}
+    num_shown = 0
+    for key in obs.keys():
+        if num_shown >= MAX_VIEWPORTS:
+            break
+        if key.startswith('pixels/') and 'latent' not in key:
+            obs_t[key] = obs[key][t]
+            num_shown += 1
+    return obs_t
+
+def metrics_env_select(metrics: Dict, i_env: int) -> Dict:
+    """Select column i_env from each metric."""
+    return {key: metrics[key][:, i_env] for key in metrics.keys()}

--- a/brax/training/rscope/rscope_utils.py
+++ b/brax/training/rscope/rscope_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Brax Authors.
+# Copyright 2025 The Brax Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,52 +16,50 @@
 
 import datetime
 import os
-import shutil
+from pathlib import PosixPath
 import pickle
+import shutil
+from typing import Any, Dict, Optional, Union
+
 import jax
 import numpy as np
-from pathlib import PosixPath
-from typing import Union, Optional, Dict, Any
-
 
 BASE_PATH = "/tmp/rscope/active_run"
 TEMP_PATH = "/tmp/rscope/temp"
 
 
-def rscope_init(xml_path: Union[PosixPath, str], 
-                model_assets: Optional[Dict[str, Any]] = None):
-    # clear the active run directory.
-    if os.path.exists(BASE_PATH):
-        shutil.rmtree(BASE_PATH)
+def rscope_init(
+    xml_path: Union[PosixPath, str],
+    model_assets: Optional[Dict[str, Any]] = None,
+):
+  # clear the active run directory.
+  if os.path.exists(BASE_PATH):
+    shutil.rmtree(BASE_PATH)
+  os.makedirs(BASE_PATH)
+
+  if not isinstance(xml_path, str):
+    xml_path = xml_path.as_posix()
+
+  rscope_meta = {"xml_path": xml_path, "model_assets": model_assets}
+  # Make the base path and temp path if they don't exist.
+  if not os.path.exists(BASE_PATH):
     os.makedirs(BASE_PATH)
+  if not os.path.exists(TEMP_PATH):
+    os.makedirs(TEMP_PATH)
 
-    if not isinstance(xml_path, str):
-        xml_path = xml_path.as_posix()
-
-    rscope_meta = {
-        "xml_path": xml_path,
-        "model_assets": model_assets
-    }
-    # Make the base path and temp path if they don't exist.
-    if not os.path.exists(BASE_PATH):
-        os.makedirs(BASE_PATH)
-    if not os.path.exists(TEMP_PATH):
-        os.makedirs(TEMP_PATH)
-
-    with open(os.path.join(BASE_PATH, "rscope_meta.pkl"), "wb") as f:
-        pickle.dump(rscope_meta, f)
+  with open(os.path.join(BASE_PATH, "rscope_meta.pkl"), "wb") as f:
+    pickle.dump(rscope_meta, f)
 
 
 def dump_eval(eval: dict):
-    # write to <datetime>.mj_unroll.
-    now = datetime.datetime.now()
-    now_str = now.strftime("%Y_%m_%d-%H_%M_%S")
-    # ensure it's numpy.
-    eval = jax.tree.map(lambda x: np.array(x), eval)
-    # 2 stages to ensure atomicity.
-    temp_path = os.path.join(TEMP_PATH, f"partial_transition.tmp")
-    final_path = os.path.join(BASE_PATH, f"{now_str}.mj_unroll")
-    with open(temp_path, "wb") as f:
-        pickle.dump(eval, f)    
-    os.rename(temp_path, 
-              final_path)
+  # write to <datetime>.mj_unroll.
+  now = datetime.datetime.now()
+  now_str = now.strftime("%Y_%m_%d-%H_%M_%S")
+  # ensure it's numpy.
+  eval = jax.tree.map(lambda x: np.array(x), eval)
+  # 2 stages to ensure atomicity.
+  temp_path = os.path.join(TEMP_PATH, f"partial_transition.tmp")
+  final_path = os.path.join(BASE_PATH, f"{now_str}.mj_unroll")
+  with open(temp_path, "wb") as f:
+    pickle.dump(eval, f)
+  os.rename(temp_path, final_path)

--- a/brax/training/rscope/rscope_utils.py
+++ b/brax/training/rscope/rscope_utils.py
@@ -1,0 +1,67 @@
+# Copyright 2024 The Brax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Brax training rscope utils."""
+
+import datetime
+import os
+import shutil
+import pickle
+import jax
+import numpy as np
+from pathlib import PosixPath
+from typing import Union, Optional, Dict, Any
+
+
+BASE_PATH = "/tmp/rscope/active_run"
+TEMP_PATH = "/tmp/rscope/temp"
+
+
+def rscope_init(xml_path: Union[PosixPath, str], 
+                model_assets: Optional[Dict[str, Any]] = None):
+    # clear the active run directory.
+    if os.path.exists(BASE_PATH):
+        shutil.rmtree(BASE_PATH)
+    os.makedirs(BASE_PATH)
+
+    if not isinstance(xml_path, str):
+        xml_path = xml_path.as_posix()
+
+    rscope_meta = {
+        "xml_path": xml_path,
+        "model_assets": model_assets
+    }
+    # Make the base path and temp path if they don't exist.
+    if not os.path.exists(BASE_PATH):
+        os.makedirs(BASE_PATH)
+    if not os.path.exists(TEMP_PATH):
+        os.makedirs(TEMP_PATH)
+
+    with open(os.path.join(BASE_PATH, "rscope_meta.pkl"), "wb") as f:
+        pickle.dump(rscope_meta, f)
+
+
+def dump_eval(eval: dict):
+    # write to <datetime>.mj_unroll.
+    now = datetime.datetime.now()
+    now_str = now.strftime("%Y_%m_%d-%H_%M_%S")
+    # ensure it's numpy.
+    eval = jax.tree.map(lambda x: np.array(x), eval)
+    # 2 stages to ensure atomicity.
+    temp_path = os.path.join(TEMP_PATH, f"partial_transition.tmp")
+    final_path = os.path.join(BASE_PATH, f"{now_str}.mj_unroll")
+    with open(temp_path, "wb") as f:
+        pickle.dump(eval, f)    
+    os.rename(temp_path, 
+              final_path)

--- a/brax/training/rscope/state.py
+++ b/brax/training/rscope/state.py
@@ -1,43 +1,62 @@
+# Copyright 2025 The Brax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rscope state."""
+
 import glfw
-import rollout
+
+import brax.training.rscope.rollout as rollout
+
 
 class ViewerState:
-    def __init__(self):
-        self.cur_eval = 0
-        self.cur_env = 0
-        self.change_rollout = True
-        self.pause = False
-        self.show_metrics = False
-        self.show_pixel_obs = False
-        self.show_help = True
 
-    def key_callback(self, keycode):
-        if keycode == glfw.KEY_RIGHT:
-            self.change_rollout = True
-            self.cur_env += 1
-        elif keycode == glfw.KEY_LEFT:
-            self.change_rollout = True
-            self.cur_env -= 1
-        elif keycode == glfw.KEY_UP:
-            self.change_rollout = True
-            self.cur_eval += 1
-        elif keycode == glfw.KEY_DOWN:
-            self.change_rollout = True
-            self.cur_eval -= 1
-        else:
-            try:
-                char = chr(keycode)
-                if char == "M":
-                    self.show_metrics = not self.show_metrics
-                elif char == "O":
-                    self.show_pixel_obs = not self.show_pixel_obs
-                elif char == " ":
-                    self.pause = not self.pause
-                elif char == "H":
-                    self.show_help = not self.show_help
-            except ValueError:
-                pass
-        
-        # Wrap to valid ranges
-        self.cur_eval = (self.cur_eval + rollout.num_evals) % rollout.num_evals
-        self.cur_env = (self.cur_env + rollout.num_envs) % rollout.num_envs
+  def __init__(self):
+    self.cur_eval = 0
+    self.cur_env = 0
+    self.change_rollout = True
+    self.pause = False
+    self.show_metrics = False
+    self.show_pixel_obs = False
+    self.show_help = True
+
+  def key_callback(self, keycode):
+    if keycode == glfw.KEY_RIGHT:
+      self.change_rollout = True
+      self.cur_env += 1
+    elif keycode == glfw.KEY_LEFT:
+      self.change_rollout = True
+      self.cur_env -= 1
+    elif keycode == glfw.KEY_UP:
+      self.change_rollout = True
+      self.cur_eval += 1
+    elif keycode == glfw.KEY_DOWN:
+      self.change_rollout = True
+      self.cur_eval -= 1
+    else:
+      try:
+        char = chr(keycode)
+        if char == "M":
+          self.show_metrics = not self.show_metrics
+        elif char == "O":
+          self.show_pixel_obs = not self.show_pixel_obs
+        elif char == " ":
+          self.pause = not self.pause
+        elif char == "H":
+          self.show_help = not self.show_help
+      except ValueError:
+        pass
+
+    # Wrap to valid ranges
+    self.cur_eval = (self.cur_eval + rollout.num_evals) % rollout.num_evals
+    self.cur_env = (self.cur_env + rollout.num_envs) % rollout.num_envs

--- a/brax/training/rscope/state.py
+++ b/brax/training/rscope/state.py
@@ -1,0 +1,43 @@
+import glfw
+import rollout
+
+class ViewerState:
+    def __init__(self):
+        self.cur_eval = 0
+        self.cur_env = 0
+        self.change_rollout = True
+        self.pause = False
+        self.show_metrics = False
+        self.show_pixel_obs = False
+        self.show_help = True
+
+    def key_callback(self, keycode):
+        if keycode == glfw.KEY_RIGHT:
+            self.change_rollout = True
+            self.cur_env += 1
+        elif keycode == glfw.KEY_LEFT:
+            self.change_rollout = True
+            self.cur_env -= 1
+        elif keycode == glfw.KEY_UP:
+            self.change_rollout = True
+            self.cur_eval += 1
+        elif keycode == glfw.KEY_DOWN:
+            self.change_rollout = True
+            self.cur_eval -= 1
+        else:
+            try:
+                char = chr(keycode)
+                if char == "M":
+                    self.show_metrics = not self.show_metrics
+                elif char == "O":
+                    self.show_pixel_obs = not self.show_pixel_obs
+                elif char == " ":
+                    self.pause = not self.pause
+                elif char == "H":
+                    self.show_help = not self.show_help
+            except ValueError:
+                pass
+        
+        # Wrap to valid ranges
+        self.cur_eval = (self.cur_eval + rollout.num_evals) % rollout.num_evals
+        self.cur_env = (self.cur_env + rollout.num_envs) % rollout.num_envs

--- a/brax/training/rscope/viewer_utils.py
+++ b/brax/training/rscope/viewer_utils.py
@@ -1,3 +1,19 @@
+# Copyright 2025 The Brax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Viewer utilities."""
+
 import mujoco
 
 MAX_VIEWPORTS = 12
@@ -6,53 +22,67 @@ y_range = [0, 0.01]
 gridsize = [3, 4]
 figures = {}
 
+
 def get_menu_text():
-    text_1 = "SHIFT + M\nSHIFT + O\nSPACE\nRIGHT/LEFT\nUP/DOWN\nSHIFT + H\nTAB"
-    text_2 = "Toggle metrics\nToggle pixel obs\nPause/play\nNext/prev env\nNext/prev eval\nToggle help\nToggle left UI"
-    return text_1, text_2
+  text_1 = 'SHIFT + M\nSHIFT + O\nSPACE\nRIGHT/LEFT\nUP/DOWN\nSHIFT + H\nTAB'
+  text_2 = (
+      'Toggle metrics\nToggle pixel obs\nPause/play\nNext/prev env\nNext/prev'
+      ' eval\nToggle help\nToggle left UI'
+  )
+  return text_1, text_2
+
 
 def get_viewports(num_viewports: int, viewer_rect: mujoco.MjrRect):
-    """Calculate viewports for the given number of plots."""
-    denom = 6 if num_viewports >= 6 else max(num_viewports, 4)
-    viewport_width = viewer_rect.width // denom
-    viewport_height = viewer_rect.height // denom
-    max_viewports_per_column = 6
-    viewports = []
-    for i in range(min(num_viewports, MAX_VIEWPORTS)):
-        column = i // max_viewports_per_column
-        row = i % max_viewports_per_column
-        left = viewer_rect.left + viewer_rect.width - (column + 1) * viewport_width
-        bottom = viewer_rect.bottom + viewer_rect.height - (row + 1) * viewport_height
-        viewports.append(
-            mujoco.MjrRect(bottom=bottom, height=viewport_height, left=left, width=viewport_width)
+  """Calculate viewports for the given number of plots."""
+  denom = 6 if num_viewports >= 6 else max(num_viewports, 4)
+  viewport_width = viewer_rect.width // denom
+  viewport_height = viewer_rect.height // denom
+  max_viewports_per_column = 6
+  viewports = []
+  for i in range(min(num_viewports, MAX_VIEWPORTS)):
+    column = i // max_viewports_per_column
+    row = i % max_viewports_per_column
+    left = viewer_rect.left + viewer_rect.width - (column + 1) * viewport_width
+    bottom = (
+        viewer_rect.bottom + viewer_rect.height - (row + 1) * viewport_height
+    )
+    viewports.append(
+        mujoco.MjrRect(
+            bottom=bottom,
+            height=viewport_height,
+            left=left,
+            width=viewport_width,
         )
-    return viewports
+    )
+  return viewports
+
 
 def reset_figures(metrics_keys_list):
-    """Initialize/reset figures for each metric."""
-    global figures
-    # Ensure that 'reward' appears first.
-    metrics_keys = metrics_keys_list.copy()
-    if 'reward' in metrics_keys:
-        metrics_keys.remove('reward')
-        metrics_keys.insert(0, 'reward')
-    for key in metrics_keys:
-        fig = mujoco.MjvFigure()
-        mujoco.mjv_defaultFigure(fig)
-        fig.flg_extend = 1
-        fig.gridsize = gridsize
-        fig.range[1] = y_range[1]
-        fig.figurergba[-1] = 0.5
-        fig.title = key
-        for i in range(MAX_LINE_POINTS):
-            fig.linedata[0][2 * i] = -float(i)
-        figures[key] = fig
+  """Initialize/reset figures for each metric."""
+  global figures
+  # Ensure that 'reward' appears first.
+  metrics_keys = metrics_keys_list.copy()
+  if 'reward' in metrics_keys:
+    metrics_keys.remove('reward')
+    metrics_keys.insert(0, 'reward')
+  for key in metrics_keys:
+    fig = mujoco.MjvFigure()
+    mujoco.mjv_defaultFigure(fig)
+    fig.flg_extend = 1
+    fig.gridsize = gridsize
+    fig.range[1] = y_range[1]
+    fig.figurergba[-1] = 0.5
+    fig.title = key
+    for i in range(MAX_LINE_POINTS):
+      fig.linedata[0][2 * i] = -float(i)
+    figures[key] = fig
+
 
 def add_data_to_fig(metric_key, data):
-    """Add a new data point to the figure for a given metric."""
-    fig = figures[metric_key]
-    pnt = min(MAX_LINE_POINTS, fig.linepnt[0] + 1)
-    for i in range(pnt - 1, 0, -1):
-        fig.linedata[0][2 * i + 1] = fig.linedata[0][2 * i - 1]
-    fig.linepnt[0] = pnt
-    fig.linedata[0][1] = data
+  """Add a new data point to the figure for a given metric."""
+  fig = figures[metric_key]
+  pnt = min(MAX_LINE_POINTS, fig.linepnt[0] + 1)
+  for i in range(pnt - 1, 0, -1):
+    fig.linedata[0][2 * i + 1] = fig.linedata[0][2 * i - 1]
+  fig.linepnt[0] = pnt
+  fig.linedata[0][1] = data

--- a/brax/training/rscope/viewer_utils.py
+++ b/brax/training/rscope/viewer_utils.py
@@ -1,0 +1,58 @@
+import mujoco
+
+MAX_VIEWPORTS = 12
+MAX_LINE_POINTS = 200
+y_range = [0, 0.01]
+gridsize = [3, 4]
+figures = {}
+
+def get_menu_text():
+    text_1 = "SHIFT + M\nSHIFT + O\nSPACE\nRIGHT/LEFT\nUP/DOWN\nSHIFT + H\nTAB"
+    text_2 = "Toggle metrics\nToggle pixel obs\nPause/play\nNext/prev env\nNext/prev eval\nToggle help\nToggle left UI"
+    return text_1, text_2
+
+def get_viewports(num_viewports: int, viewer_rect: mujoco.MjrRect):
+    """Calculate viewports for the given number of plots."""
+    denom = 6 if num_viewports >= 6 else max(num_viewports, 4)
+    viewport_width = viewer_rect.width // denom
+    viewport_height = viewer_rect.height // denom
+    max_viewports_per_column = 6
+    viewports = []
+    for i in range(min(num_viewports, MAX_VIEWPORTS)):
+        column = i // max_viewports_per_column
+        row = i % max_viewports_per_column
+        left = viewer_rect.left + viewer_rect.width - (column + 1) * viewport_width
+        bottom = viewer_rect.bottom + viewer_rect.height - (row + 1) * viewport_height
+        viewports.append(
+            mujoco.MjrRect(bottom=bottom, height=viewport_height, left=left, width=viewport_width)
+        )
+    return viewports
+
+def reset_figures(metrics_keys_list):
+    """Initialize/reset figures for each metric."""
+    global figures
+    # Ensure that 'reward' appears first.
+    metrics_keys = metrics_keys_list.copy()
+    if 'reward' in metrics_keys:
+        metrics_keys.remove('reward')
+        metrics_keys.insert(0, 'reward')
+    for key in metrics_keys:
+        fig = mujoco.MjvFigure()
+        mujoco.mjv_defaultFigure(fig)
+        fig.flg_extend = 1
+        fig.gridsize = gridsize
+        fig.range[1] = y_range[1]
+        fig.figurergba[-1] = 0.5
+        fig.title = key
+        for i in range(MAX_LINE_POINTS):
+            fig.linedata[0][2 * i] = -float(i)
+        figures[key] = fig
+
+def add_data_to_fig(metric_key, data):
+    """Add a new data point to the figure for a given metric."""
+    fig = figures[metric_key]
+    pnt = min(MAX_LINE_POINTS, fig.linepnt[0] + 1)
+    for i in range(pnt - 1, 0, -1):
+        fig.linedata[0][2 * i + 1] = fig.linedata[0][2 * i - 1]
+    fig.linepnt[0] = pnt
+    fig.linedata[0][1] = data


### PR DESCRIPTION
Please see the [readme](https://github.com/Andrew-Luo1/brax/tree/rscope/brax/training/rscope) for details.

Two design notes for discussion:

**1. Rscope currently involves dumping trajectories to /tmp/rscope/active_runs for visualisation**
The alternative would be to load the policy checkpoints during training and collect new unrolls with them. While this would require a bit less change to the existing codebase, it wouldly likely complicate rscope's design. Additionally, with the dumping approach, you can use rscope as evals come in *during the training process*, since running the mujoco viewer doesn't require GPU. This drastically shortens the feedback cycle.

**2. Proposed changes to evaluator**
This PR proposes to add the optional argument `rscope_envs` to `Class Evaluator`. If set to None, you recover the original evaluator logic. Capturing full trajectories for 16 envs, with `rscope_envs=16` gives a 1% longer `eval/epoch_eval_time` metric for state-based RL and 5% for pixel-based, evaluated on PandaPickCube and CartpoleBalance (vision=True) respectively.

Looking forward to feedback! It would be great to share this tool with the community.

Depends on [Mujoco PR 2503](https://github.com/google-deepmind/mujoco/pull/2503)
Enables [Playground PR 83](https://github.com/google-deepmind/mujoco_playground/pull/83)