### PR TITLE
Fix error in UInt64: ufunc 'right_shift' not supported for the input types ... according to the casting rule ''safe''

### DIFF
--- a/brax/training/types.py
+++ b/brax/training/types.py
@@ -109,7 +109,7 @@ class UInt64:
     """Convert UInt64 to numpy uint64."""
     hi_np = np.array(self.hi, dtype=np.uint64)
     lo_np = np.array(self.lo, dtype=np.uint64)
-    return (hi_np << 32) | lo_np
+    return (hi_np << np.uint64(32)) | lo_np
 
   def __post_init__(self):
     """Cast post init."""


### PR DESCRIPTION
Fixes error in UInt64.to_numpy: 
```
TypeError: ufunc 'right_shift' not supported for the input types,
and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```