### PR TITLE
Trace environment trajectories during eval unroll

### DIFF
--- a/brax/envs/wrappers/training.py
+++ b/brax/envs/wrappers/training.py
@@ -217,6 +217,29 @@ class EvalWrapper(Wrapper):
     return nstate
 
 
+class TraceEvalWrapper(Wrapper):
+  """Saves full trajectories in state.info for rendering."""
+  def reset(self, rng: jax.Array) -> State:
+    state = self.env.reset(rng)
+    self._store(state)
+    return state
+
+  def step(self, state: State, action: jax.Array) -> State:
+      state = self.env.step(state, action)
+      self._store(state)
+      return state
+
+  def _store(self, state: State):
+    state.info['trace'] = {
+        'qpos': state.data.qpos,
+        'qvel': state.data.qvel,
+        'time': state.data.time,
+        'metrics': state.metrics}
+    if hasattr(state.data, 'mocap_pos') and hasattr(state.data, 'mocap_quat'):
+        state.info['trace']['mocap_pos'] = state.data.mocap_pos
+        state.info['trace']['mocap_quat'] = state.data.mocap_quat
+
+
 class DomainRandomizationVmapWrapper(Wrapper):
   """Wrapper for domain randomization."""
 

--- a/brax/training/acting.py
+++ b/brax/training/acting.py
@@ -15,7 +15,7 @@
 """Brax training acting functions."""
 
 import time
-from typing import Callable, Sequence, Tuple
+from typing import Callable, Sequence, Tuple, Optional
 
 from brax import envs
 from brax.training.types import Metrics
@@ -58,6 +58,7 @@ def generate_unroll(
     key: PRNGKey,
     unroll_length: int,
     extra_fields: Sequence[str] = (),
+    num_traced_envs: Optional[int] = None
 ) -> Tuple[State, Transition]:
   """Collect trajectories of given unroll_length."""
 
@@ -68,6 +69,9 @@ def generate_unroll(
     nstate, transition = actor_step(
         env, state, policy, current_key, extra_fields=extra_fields
     )
+    if num_traced_envs:
+      # (E, ...) -> (num_traced_envs, ...)
+      transition = jax.tree.map(lambda x: x[:num_traced_envs], transition)
     return (nstate, next_key), transition
 
   (final_state, _), data = jax.lax.scan(
@@ -88,6 +92,7 @@ class Evaluator:
       episode_length: int,
       action_repeat: int,
       key: PRNGKey,
+      num_traced_envs: Optional[int] = None
   ):
     """Init.
 
@@ -103,22 +108,29 @@ class Evaluator:
     self._eval_walltime = 0.0
 
     eval_env = envs.training.EvalWrapper(eval_env)
-
+    if num_traced_envs:
+      eval_env = envs.training.TraceEvalWrapper(eval_env)
     def generate_eval_unroll(
         policy_params: PolicyParams, key: PRNGKey
     ) -> State:
       reset_keys = jax.random.split(key, num_eval_envs)
       eval_first_state = eval_env.reset(reset_keys)
-      return generate_unroll(
+      final_state, data = generate_unroll(
           eval_env,
           eval_first_state,
           eval_policy_fn(policy_params),
           key,
           unroll_length=episode_length // action_repeat,
-      )[0]
+          extra_fields = ('trace',) if num_traced_envs else (),
+          num_traced_envs=num_traced_envs,
+      )
+      if num_traced_envs:
+        return final_state, data
+      return final_state
 
     self._generate_eval_unroll = jax.jit(generate_eval_unroll)
     self._steps_per_unroll = episode_length * num_eval_envs
+    self._num_traced_envs = num_traced_envs
 
   def run_evaluation(
       self,
@@ -131,6 +143,8 @@ class Evaluator:
 
     t = time.time()
     eval_state = self._generate_eval_unroll(policy_params, unroll_key)
+    if self._num_traced_envs:
+      eval_state, eval_data = eval_state
     eval_metrics = eval_state.info['eval_metrics']
     eval_metrics.active_episodes.block_until_ready()
     epoch_eval_time = time.time() - t
@@ -153,5 +167,6 @@ class Evaluator:
         **training_metrics,
         **metrics,
     }
-
+    if self._num_traced_envs:
+      metrics['eval/data'] = eval_data
     return metrics  # pytype: disable=bad-return-type  # jax-ndarray

--- a/brax/training/agents/ppo/train.py
+++ b/brax/training/agents/ppo/train.py
@@ -312,6 +312,7 @@ def train(
       or use a random initialization
     num_traced_envs: the number of envs whose trajectories will be traced during evaluation.
       Does not noticeably affect evaluation time.
+
   Returns:
     Tuple of (make_policy function, network params, metrics)
   """

--- a/brax/training/agents/ppo/train.py
+++ b/brax/training/agents/ppo/train.py
@@ -241,6 +241,7 @@ def train(
     restore_checkpoint_path: Optional[str] = None,
     restore_params: Optional[Any] = None,
     restore_value_fn: bool = True,
+    num_traced_envs: Optional[int] = None,
 ):
   """PPO training.
 
@@ -309,7 +310,8 @@ def train(
       from the return values of ppo.train().
     restore_value_fn: whether to restore the value function from the checkpoint
       or use a random initialization
-
+    num_traced_envs: the number of envs whose trajectories will be traced during evaluation.
+      Does not noticeably affect evaluation time.
   Returns:
     Tuple of (make_policy function, network params, metrics)
   """
@@ -659,6 +661,7 @@ def train(
       episode_length=episode_length,
       action_repeat=action_repeat,
       key=eval_key,
+      num_traced_envs=num_traced_envs,
   )
 
   # Run initial eval


### PR DESCRIPTION
Enables live visualization of robot trajectories during the training process, for example via [rscope](https://github.com/Andrew-Luo1/rscope).

Tracing is by default turned off, so perf for existing workflows shouldn't be impacted.

When tracing is turned on, perf differences are minor. (~1% slowdown for state-based, 5% for pixel-based ; 16 traced envs)
