### PR TITLE
policy_params_fn

### DIFF
--- a/brax/training/agents/sac/train.py
+++ b/brax/training/agents/sac/train.py
@@ -136,6 +136,7 @@ def train(
         sac_networks.SACNetworks
     ] = sac_networks.make_sac_networks,
     progress_fn: Callable[[int, Metrics], None] = lambda *args: None,
+    policy_params_fn: Callable[..., None] = lambda *args: None,
     eval_env: Optional[envs.Env] = None,
     randomization_fn: Optional[
         Callable[[base.System, jnp.ndarray], Tuple[base.System, base.System]]
@@ -557,6 +558,12 @@ def train(
   training_walltime = time.time() - t
 
   current_step = 0
+  
+  params = _unpmap(
+        (training_state.normalizer_params, training_state.policy_params)
+    )
+  policy_params_fn(current_step, make_policy, params)
+
   for _ in range(num_evals_after_init):
     logging.info('step %s', current_step)
 
@@ -572,10 +579,11 @@ def train(
 
     # Eval and logging
     if process_id == 0:
-      if checkpoint_logdir:
-        params = _unpmap(
+      params = _unpmap(
             (training_state.normalizer_params, training_state.policy_params)
         )
+      policy_params_fn(current_step, make_policy, params)
+      if checkpoint_logdir:
         ckpt_config = checkpoint.network_config(
             observation_size=obs_size,
             action_size=env.action_size,


### PR DESCRIPTION
Brax PPO can be passed a policy_params_fn:

policy_params_fn: a user-defined callback function that can be used for
      saving custom policy checkpoints or creating policy rollouts and videos
      
I personally find this feature useful for rendering throughout training.

I've added this functionality to BRAX SAC.