### PR TITLE
Store terminal observations in infos for value bootstrap

### DIFF
--- a/brax/envs/wrappers/training.py
+++ b/brax/envs/wrappers/training.py
@@ -133,6 +133,7 @@ class AutoResetWrapper(Wrapper):
     state = self.env.reset(rng)
     state.info['first_pipeline_state'] = state.pipeline_state
     state.info['first_obs'] = state.obs
+    state.info["obs_st"] = state.obs
     return state
 
   def step(self, state: State, action: jax.Array) -> State:
@@ -142,6 +143,9 @@ class AutoResetWrapper(Wrapper):
       state.info.update(steps=steps)
     state = state.replace(done=jp.zeros_like(state.done))
     state = self.env.step(state, action)
+
+    # Store next_obs before reset
+    obs_st = state.obs
 
     def where_done(x, y):
       done = state.done
@@ -155,6 +159,7 @@ class AutoResetWrapper(Wrapper):
         where_done, state.info['first_pipeline_state'], state.pipeline_state
     )
     obs = jax.tree.map(where_done, state.info['first_obs'], state.obs)
+    state.info["obs_st"] = obs_st
     return state.replace(pipeline_state=pipeline_state, obs=obs)
 
 


### PR DESCRIPTION
Hello,

Differentiating between truncation and termination of episodes is key to proper value estimation. Brax already exposes `truncation` and `episode_done` flags as part of `infos` which allows to make the distinction. 

When using the `AutoResetWrapper ` (which is desirable)  and encountering a terminal state, the returned state (and therefore observation) is the first state of the **new** episode. However, when doing value estimation in such states, one wishes to compute the value of the **last** state for value bootstrap. For a terminal (not truncated) state, this poses no issue as the value is 0 and the state can be ignored, however for a truncated state one needs to predict the value of the said state (not the first state of the new episode). This is not possible at the moment as this state is never exposed.

I propose adding a simple `obs_st` field in the infos returned through the AutoResetWrapper, which exposes this info to users for correct value bootstrapping. 

I have added the corresponding test, and all tests pass.

I am new to open source-contributions and I could not find a style guide or a linter for brax. Please tell me if there are any modifications to be made.