### PR TITLE
Fix reset function call in PPO training

### DIFF
--- a/brax/training/agents/ppo/train.py
+++ b/brax/training/agents/ppo/train.py
@@ -775,7 +775,7 @@ def train(
       )(key_envs, key_envs.shape[1])
       # TODO(brax-team): move extra reset logic to the AutoResetWrapper.
       if num_resets_per_eval > 0:
-        env_state = reset_fn((training_state, env_state), key_envs)
+        env_state = reset_fn(env_state, key_envs)
 
     if process_id != 0:
       continue


### PR DESCRIPTION
Hi,

Thanks for the great project!

I think there is an issue in the calling behaviour of the `reset_fn`. 

In particular, the existing code passes training_state to reset_fn, but the first argument is donated.

What this ends up doing is that in certain cases (e.g. small numbers of environments) the training buffer is deleted.


The fix is straightforward---just don't pass the training state to the function; this now has the (I think) desired behaviour of donating/deleting only the env_state buffer which is being overwritten anyways.



Please let me know if there are any issues with this, thanks!