### PR TITLE
math: scan solve_pgs iterations

### DIFF
--- a/brax/math.py
+++ b/brax/math.py
@@ -268,9 +268,11 @@ def solve_pgs(a: jax.Array, b: jax.Array, num_iters: int) -> jax.Array:
 
     return x, None
 
-  # TODO(brax-team): turn this into a scan
-  for _ in range(num_iters):
+  def iterate(x, _):
     x, _ = jax.lax.scan(get_x, x, (jp.arange(num_rows), a, b))
+    return x, None
+
+  x, _ = jax.lax.scan(iterate, x, None, length=num_iters)
 
   return x
 

--- a/brax/math_test.py
+++ b/brax/math_test.py
@@ -65,6 +65,13 @@ class MathTest(absltest.TestCase):
     rot = math.from_to(v1, v2)
     np.testing.assert_array_almost_equal(v2, math.rotate(v1, rot))
 
+  def test_solve_pgs_diagonal(self):
+    a = jp.diag(jp.array([2.0, 4.0, 8.0]))
+    b = jp.array([-2.0, 2.0, -8.0])
+    expected = jp.array([1.0, 0.0, 1.0])
+    x = math.solve_pgs(a, b, num_iters=2)
+    np.testing.assert_allclose(x, expected, rtol=1e-6, atol=1e-6)
+
 
 class OrthoganalsTest(parameterized.TestCase):
   """Tests the orthogonals function."""


### PR DESCRIPTION
## Summary
- replace the Python for-loop in solve_pgs with a lax.scan over iterations
- add a diagonal system test to validate projected solution

## Testing
- python3.11 -m venv .venv-test
- pip install -e .
- pip install pytest
- pytest brax/math_test.py -q
