### PR TITLE
Support callable entropy schedules in PPO

### DIFF
--- a/brax/training/agents/ppo/losses.py
+++ b/brax/training/agents/ppo/losses.py
@@ -213,6 +213,7 @@ def compute_ppo_loss(
       'policy_loss': policy_loss,
       'v_loss': v_loss,
       'entropy_loss': entropy_loss,
+      'entropy_cost': entropy_cost,
       'kl_mean': kl,
       'policy_dist_mean_std': policy_dist_mean_std,
   }


### PR DESCRIPTION
## Summary

PPO currently accepts a fixed entropy coefficient. Allow `entropy_cost` to also accept an Optax-compatible callable, supporting linear, cosine, warmup, piecewise, and custom schedules without new trainer flags. The scalar default and existing positional arguments are unchanged.

For example:

```python
entropy_cost = optax.cosine_decay_schedule(1e-2, decay_steps=1_000_000)
```

Pass this as `entropy_cost` to `ppo.train`. The schedule receives the total environment-step count, including `action_repeat`, once per rollout batch. All gradient updates on that batch share the coefficient. Counts start at zero for each train call, including parameter restoration. `training/entropy_cost` reports the mean applied coefficient.

## Testing

- 60 tests pass across PPO training, losses, checkpointing, and UInt64 types on CPU with Python 3.12 and JAX 0.11.1. This includes 11 new tests for schedule values, UInt64 rollover, scalar equivalence, float64 precision, and the environment-step clock.
- Four tiny PPO runs match upstream `bb77b328` exactly for default and explicit scalar coefficients with JAX x64 disabled and enabled, including parameters and common non-timing metrics.
