### PR TITLE
Warn when init_noise_std and related params are ignored with tanh_normal (#661)

### DIFF
--- a/brax/training/agents/ppo/networks.py
+++ b/brax/training/agents/ppo/networks.py
@@ -14,6 +14,7 @@
 
 """PPO networks."""
 
+import warnings
 from typing import Any, Literal, Mapping, Sequence, Tuple
 
 from brax.training import distribution
@@ -115,6 +116,23 @@ def make_ppo_networks(
   policy_kernel_init_kwargs = policy_network_kernel_init_kwargs or {}
   value_kernel_init_kwargs = value_network_kernel_init_kwargs or {}
   mean_kernel_init_kwargs_ = mean_kernel_init_kwargs or {}
+
+  if distribution_type == 'tanh_normal':
+    ignored = []
+    if init_noise_std != 1.0:
+      ignored.append(f'init_noise_std={init_noise_std!r}')
+    if noise_std_type != 'scalar':
+      ignored.append(f'noise_std_type={noise_std_type!r}')
+    if state_dependent_std:
+      ignored.append(f'state_dependent_std={state_dependent_std!r}')
+    if ignored:
+      warnings.warn(
+          f'{", ".join(ignored)} {"has" if len(ignored) == 1 else "have"}'
+          ' no effect with distribution_type="tanh_normal". The standard'
+          ' deviation is determined entirely by the policy network output.'
+          ' These parameters only apply to distribution_type="normal".',
+          stacklevel=2,
+      )
 
   parametric_action_distribution: distribution.ParametricDistribution
   if distribution_type == 'normal':


### PR DESCRIPTION
Fixes #661.

## Problem

When using `make_ppo_networks()` with the default `distribution_type='tanh_normal'`, the `init_noise_std`, `noise_std_type`, and `state_dependent_std` parameters are accepted without error but have **no effect**. The `tanh_normal` branch creates a plain MLP whose output fully determines the standard deviation via `softplus` in `NormalTanhDistribution.create_dist()`. Only the `normal` branch uses `PolicyModuleWithStd` where these parameters actually initialize a learnable noise parameter.

As the reporter noted, this means any hyperparameter sweep over `init_noise_std` under the default `tanh_normal` produces identical results, wasted compute with zero feedback.

## Fix

Emit a `warnings.warn()` listing the non-default parameters when `distribution_type='tanh_normal'` and any of `init_noise_std`, `noise_std_type`, or `state_dependent_std` differ from their defaults. The warning fires once at network construction time and includes actionable guidance ("These parameters only apply to distribution_type='normal'").

This is the least-invasive option from the reporter's suggestions, no breaking changes, no API restructure, just a clear signal that the parameters are being ignored.

## Example

```python
make_ppo_networks(obs_size, act_size, init_noise_std=0.5)
# UserWarning: init_noise_std=0.5 has no effect with
# distribution_type="tanh_normal". The standard deviation is determined
# entirely by the policy network output. These parameters only apply to
# distribution_type="normal".
```